### PR TITLE
- Added desktop startup of kinto service

### DIFF
--- a/keyswap_service.sh
+++ b/keyswap_service.sh
@@ -6,7 +6,9 @@ systemctl --user stop keyswap.timer >/dev/null 2>&1
 systemctl --user disable keyswap.timer >/dev/null 2>&1
 swapcmd="\/bin\/bash\ \/home\/`whoami`\/.config\/kinto\/xactive.sh"
 mkdir -p ~/.config/systemd/user
+mkdir -p ~/.config/autostart
 cp ./system-config/keyswap.service ~/.config/systemd/user/keyswap.service
+cp ./system-config/kinto.desktop ~/.config/autostart/kinto.desktop
 cp ./kintox11/binary/kintox11 ~/.config/kinto/kintox11
 cp ./system-config/xactive.sh ~/.config/kinto/xactive.sh
 sed -i "s/{username}/`whoami`/g" ~/.config/systemd/user/keyswap.service

--- a/system-config/kinto.desktop
+++ b/system-config/kinto.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Kinto
+GenericName=Kinto
+Comment=Make Linux Type Like it's a Mac
+Exec=/bin/systemctrl --user start keyswap
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
- Once removed, but brought back again as it actually fixes a bug where systemd fails to restart the service on user logoff and logon.