### PR TITLE
- word-wise update

### DIFF
--- a/.xkb/symbols/mac_gui
+++ b/.xkb/symbols/mac_gui
@@ -1,15 +1,15 @@
 default partial xkb_symbols "mac_levelssym" {
-    // LEFT to Begin Line
+    // LEFT to Begin Line or Beginning of word
     replace key <LEFT> {
         type[Group1]= "ONE_LEVEL_CTRL",
         symbols[Group1]= [         Left,         Left, NoSymbol ],
-        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<HOME>,clearmods=Control)]
+        actions[Group1]= [      NoAction(), RedirectKey(key=<LEFT>,modifiers=Control,clearmods=Mod1), RedirectKey(key=<HOME>,clearmods=Control)]
     };
-    // Right to End of Line
+    // Right to End of Line or end of word
     replace key <RGHT> {
         type[Group1]= "ONE_LEVEL_CTRL",
         symbols[Group1]= [         Right,         Right, NoSymbol ],
-        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<END>,clearmods=Control)]
+        actions[Group1]= [      NoAction(), RedirectKey(key=<RGHT>,modifiers=Control,clearmods=Mod1), RedirectKey(key=<END>,clearmods=Control)]
     };
     // Up to Mac Home
     replace key <UP> {

--- a/.xkb/types/mac_gui
+++ b/.xkb/types/mac_gui
@@ -1,20 +1,11 @@
 default partial xkb_types "addmac_levels" {
     type "ONE_LEVEL_CTRL" {
-        modifiers= Shift+Control;
-        map[Shift]= Level2;
+        modifiers= Mod1+Control;
+        map[Mod1]= Level2;
         map[Control]= Level3;
-        map[Shift+Control]= Level3;
+        map[Mod1+Control]= Level3;
         level_name[Level1]= "Base";
-        level_name[Level2]= "Caps";
-        level_name[Level3]= "With Control";
-    };
-    type "TWO_LEVEL_CTRL" {
-        modifiers= Shift+Control;
-        map[Shift]= Level2;
-        map[Control]= Level3;
-        map[Shift+Control]= Level3;
-        level_name[Level1]= "Base";
-        level_name[Level2]= "Caps";
+        level_name[Level2]= "Alt";
         level_name[Level3]= "With Control";
     };
 };


### PR DESCRIPTION
Alt+Left/Right to send cursor to begin/end of word while in GUI apps. This feature was not actually tied to a lack of OS/system-wide default like I had previously thought.

Note: If this creates a problem for some apps then you may want to create an exception category and a separate xkb definition to avoid the Alt arrow remaps. But I am not aware of any conflicts so this is going into master as is.