### PR TITLE
Wordwise selections

### DIFF
--- a/.xkb/symbols/mac_gui
+++ b/.xkb/symbols/mac_gui
@@ -29,6 +29,34 @@ default partial xkb_symbols "mac_levelssym" {
        symbols[Group1]= [       BackSpace,       BackSpace, NoSymbol ],
        actions[Group1]= [      NoAction(),      RedirectKey(key=<DELE>,clearmods=Mod1), NoAction()]
     };
+    // // Full Print Screen
+    // // GalliumOS
+    // replace key <AE03> {
+    //     type[Group1]= "ONE_LEVEL_CTRL",
+    //     symbols[Group1]= [         3,         3, 3, F5 ],
+    //     actions[Group1]= [      NoAction(),      NoAction(), NoAction(), RedirectKey(key=<FK05>,clearmods=Shift) ]
+    // };
+    // // Region Print Screen
+    // // GalliumOS
+    // replace key <AE04> {
+    //     type[Group1]= "ONE_LEVEL_CTRL",
+    //     symbols[Group1]= [         4,         4, 4, F5 ],
+    //     actions[Group1]= [      NoAction(),      NoAction(), NoAction(), RedirectKey(key=<FK05>) ]
+    // };
+    // // Full Print Screen
+    // // Standard Ubuntu
+    // replace key <AE03> {
+    //     type[Group1]= "ONE_LEVEL_CTRL",
+    //     symbols[Group1]= [         3,         3, 3, F5 ],
+    //     actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<PRSC>,clearmods=Shift+Control) ]
+    // };
+    // // Region Print Screen
+    // // Standard Ubuntu
+    // replace key <AE04> {
+    //     type[Group1]= "ONE_LEVEL_CTRL",
+    //     symbols[Group1]= [         4,         4, 4, F5 ],
+    //     actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<PRSC>,clearmods=Control) ]
+    // };
 };
 partial xkb_symbols "mac_chrome" {
     // Back Button

--- a/.xkb/symbols/mac_gui
+++ b/.xkb/symbols/mac_gui
@@ -2,14 +2,26 @@ default partial xkb_symbols "mac_levelssym" {
     // LEFT to Begin Line or Beginning of word
     replace key <LEFT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         Left,         Left, NoSymbol ],
-        actions[Group1]= [      NoAction(), RedirectKey(key=<LEFT>,modifiers=Control,clearmods=Mod1), RedirectKey(key=<HOME>,clearmods=Control)]
+        symbols[Group1]= [         Left,         Left, NoSymbol,NoSymbol,Left ],
+        actions[Group1]= [
+            NoAction(),
+            RedirectKey(key=<LEFT>,modifiers=Control,clearmods=Mod1),
+            RedirectKey(key=<HOME>,clearmods=Control),
+            RedirectKey(key=<HOME>,modifiers=Shift,clearmods=Control+Mod1),
+            RedirectKey(key=<LEFT>,modifiers=Shift+Control,clearmods=Mod1)
+        ]
     };
     // Right to End of Line or end of word
     replace key <RGHT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         Right,         Right, NoSymbol ],
-        actions[Group1]= [      NoAction(), RedirectKey(key=<RGHT>,modifiers=Control,clearmods=Mod1), RedirectKey(key=<END>,clearmods=Control)]
+        symbols[Group1]= [         Right,         Right, NoSymbol, NoSymbol,Right ],
+        actions[Group1]= [
+            NoAction(),
+            RedirectKey(key=<RGHT>,modifiers=Control,clearmods=Mod1),
+            RedirectKey(key=<END>,clearmods=Control),
+            RedirectKey(key=<END>,modifiers=Shift,clearmods=Control+Mod1),
+            RedirectKey(key=<RGHT>,modifiers=Shift+Control,clearmods=Mod1)
+        ]
     };
     // Up to Mac Home
     replace key <UP> {

--- a/.xkb/symbols/mac_term
+++ b/.xkb/symbols/mac_term
@@ -35,4 +35,18 @@ default partial xkb_symbols "mac_levelssym" {
         symbols[Group1]= [         RGHT,         RGHT, NoSymbol ],
         actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<END>,clearmods=Shift+Control)]
     };
+    // Full Print Screen
+    // Standard Ubuntu
+    replace key <AE03> {
+        type[Group1]= "ONE_LEVEL_CTRL",
+        symbols[Group1]= [         3,         numbersign, NoSymbol ],
+        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<PRSC>,clearmods=Shift+Control) ]
+    };
+    // Region Print Screen
+    // Standard Ubuntu
+    replace key <AE04> {
+        type[Group1]= "ONE_LEVEL_CTRL",
+        symbols[Group1]= [         4,         dollar, NoSymbol ],
+        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<PRSC>,clearmods=Control) ]
+    };
 };

--- a/.xkb/symbols/mac_term_chromebook
+++ b/.xkb/symbols/mac_term_chromebook
@@ -26,13 +26,27 @@ default partial xkb_symbols "mac_levelssym" {
     // HOME
     replace key <LEFT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         Up,         Up, NoSymbol ],
+        symbols[Group1]= [         Left,         Left, NoSymbol ],
         actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<HOME>,clearmods=Shift+Control)]
     };
     // END
     replace key <RGHT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         Down,         Down, NoSymbol ],
+        symbols[Group1]= [         RGHT,         RGHT, NoSymbol ],
         actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<END>,clearmods=Shift+Control)]
+    };
+    // Full Print Screen
+    // GalliumOS
+    replace key <AE03> {
+        type[Group1]= "ONE_LEVEL_CTRL",
+        symbols[Group1]= [         3,         numbersign, F5 ],
+        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<FK05>,clearmods=Shift) ]
+    };
+    // Region Print Screen
+    // GalliumOS
+    replace key <AE04> {
+        type[Group1]= "ONE_LEVEL_CTRL",
+        symbols[Group1]= [         4,         dollar, F5 ],
+        actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<FK05>) ]
     };
 };

--- a/.xkb/types/mac_gui
+++ b/.xkb/types/mac_gui
@@ -5,9 +5,11 @@ default partial xkb_types "addmac_levels" {
         map[Control]= Level3;
         map[Mod1+Control]= Level3;
         map[Shift+Control]= Level4;
+        map[Shift+Mod1] = Level5;
         level_name[Level1]= "Base";
         level_name[Level2]= "Alt";
-        level_name[Level3]= "With Control";
-        level_name[Level4]= "Shift";
+        level_name[Level3]= "Control";
+        level_name[Level4]= "Shift with Control";
+        level_name[Level5] = "Shift Alt";
     };
 };

--- a/.xkb/types/mac_gui
+++ b/.xkb/types/mac_gui
@@ -1,11 +1,13 @@
 default partial xkb_types "addmac_levels" {
     type "ONE_LEVEL_CTRL" {
-        modifiers= Mod1+Control;
+        modifiers= Mod1+Control+Shift;
         map[Mod1]= Level2;
         map[Control]= Level3;
         map[Mod1+Control]= Level3;
+        map[Shift+Control]= Level4;
         level_name[Level1]= "Base";
         level_name[Level2]= "Alt";
         level_name[Level3]= "With Control";
+        level_name[Level4]= "Shift";
     };
 };


### PR DESCRIPTION
- You can now use wordwise while holding down shift.
- Partial update for screenshot capabilities with Cmd+Shift+3/4. Only implemented for terminals, will be broken apart later for gui application as well - as code has been written to support default screenshot shortcuts of Ubuntu and GalliumOS for chromebooks.