### PR TITLE
Error fix related to mac_term

### DIFF
--- a/.xkb/symbols/mac_term
+++ b/.xkb/symbols/mac_term
@@ -32,7 +32,7 @@ default partial xkb_symbols "mac_levelssym" {
     // END
     replace key <RGHT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         RGHT,         RGHT, NoSymbol ],
+        symbols[Group1]= [         Right,         Right, NoSymbol ],
         actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<END>,clearmods=Shift+Control)]
     };
     // Full Print Screen

--- a/.xkb/symbols/mac_term_chromebook
+++ b/.xkb/symbols/mac_term_chromebook
@@ -32,7 +32,7 @@ default partial xkb_symbols "mac_levelssym" {
     // END
     replace key <RGHT> {
         type[Group1]= "ONE_LEVEL_CTRL",
-        symbols[Group1]= [         RGHT,         RGHT, NoSymbol ],
+        symbols[Group1]= [         Right,         Right, NoSymbol ],
         actions[Group1]= [      NoAction(),      NoAction(), RedirectKey(key=<END>,clearmods=Shift+Control)]
     };
     // Full Print Screen


### PR DESCRIPTION
A label was off in the earlier 1.0.5-5 update. Fixing it here.