### PR TITLE
- Fixes mapping issue on Windows keyboards

### DIFF
--- a/.xkb/symbols/mac_term
+++ b/.xkb/symbols/mac_term
@@ -1,4 +1,4 @@
-default partial xkb_symbols "mac_levelssym" {
+default partial xkb_symbols "mac_apple" {
     key <LWIN> {
       repeat= no,
       type= "ONE_LEVEL",
@@ -11,6 +11,22 @@ default partial xkb_symbols "mac_levelssym" {
       symbols[Group1]= [ Hyper_R ],
       actions[group1]=[ SetMods(modifiers=Shift+Control) ]
     };
+};
+partial xkb_symbols "mac_win" {
+    key <LALT> {
+      repeat= no,
+      type= "ONE_LEVEL",
+      symbols[Group1]= [ Hyper_L ],
+      actions[group1]=[ SetMods(modifiers=Shift+Control) ]
+    };
+    key <RALT> {
+      repeat= no,
+      type= "ONE_LEVEL",
+      symbols[Group1]= [ Hyper_R ],
+      actions[group1]=[ SetMods(modifiers=Shift+Control) ]
+    };
+};
+partial xkb_symbols "mac_global" {
     // Page Up
     replace key <UP> {
         type[Group1]= "ONE_LEVEL_CTRL",

--- a/defaults.json
+++ b/defaults.json
@@ -12,7 +12,7 @@
 		"gui":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.gui $DISPLAY",
 		"term":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.term $DISPLAY",
 		"xkb_symbols_gui":"+altwin(ctrl_alt_win)+mac_gui(mac_levelssym)",
-		"xkb_symbols_term":"+altwin(swap_alt_win)+mac_term(mac_levelssym)",
+		"xkb_symbols_term":"+altwin(swap_alt_win)+mac_term(mac_win)+mac_term(mac_global)",
 		"xkb_types_gui":"+mac_gui(addmac_levels)",
 		"xkb_types_term":"+mac_term(addmac_levels)"
 	},
@@ -25,7 +25,7 @@
 		"gui":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.gui $DISPLAY",
 		"term":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.term $DISPLAY",
 		"xkb_symbols_gui":"+altwin(ctrl_alt_win)+mac_gui(mac_levelssym)",
-		"xkb_symbols_term":"+altwin(swap_alt_win)+mac_term(mac_levelssym)",
+		"xkb_symbols_term":"+altwin(swap_alt_win)+mac_term(mac_win)+mac_term(mac_global)",
 		"xkb_types_gui":"+mac_gui(addmac_levels)",
 		"xkb_types_term":"+mac_term(addmac_levels)",
 		"hack": "echo '1' | sudo tee -a /sys/module/hid_apple/parameters/swap_opt_cmd;echo 'options hid_apple swap_opt_cmd=1' | sudo tee -a /etc/modprobe.d/hid_apple.conf;sudo update-initramfs -u -k all"
@@ -39,7 +39,7 @@
 		"gui":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.gui $DISPLAY",
 		"term":"setxkbmap -option;xkbcomp -w0 -I$HOME/.xkb ~/.xkb/keymap/kbd.mac.term $DISPLAY",
 		"xkb_symbols_gui":"+ctrl(swap_lwin_lctl)+ctrl(swap_rwin_rctl)+mac_gui(mac_levelssym)",
-		"xkb_symbols_term":"+altwin(alt_super_win)+mac_term(mac_levelssym)",
+		"xkb_symbols_term":"+altwin(alt_super_win)+mac_term(mac_apple)+mac_term(mac_global)",
 		"xkb_types_gui":"+mac_gui(addmac_levels)",
 		"xkb_types_term":"+mac_term(addmac_levels)"
 	},


### PR DESCRIPTION
Kinda major in my opinion, as it impacted both Windows keyboards and Apple keyboards with the hid driver. Up until now Kinto has only been running right for macbook laptop keyboards and chromebooks, but this update fixes that.

The fault was due to a major change in Kinto going back to moving away from Super for terminal usage and directly to Ctrl+Shift.