### PR TITLE
- Adds ibus-setup & Epiphany. Closes issue #53.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,20 +45,21 @@ if len(check_x11) == 0:
 
 check_xbind = cmdline("which xbindkeys 2>/dev/null").strip()
 check_xdotool = cmdline("which xdotool 2>/dev/null").strip()
+check_ibus = cmdline("which ibus-setup 2>/dev/null").strip()
 
-pkgm = cmdline("which apt 2>/dev/null").strip()
+pkgm = cmdline("which apt-get 2>/dev/null").strip()
 
 if len(pkgm) == 0:
 	pkgm = cmdline("which dnf 2>/dev/null").strip()
 	if len(pkgm) > 0:
-		pkgm += " install -y "
+		pkgm += " check-update;sudo dnf install -y "
 else:
-	pkgm += " install -y "
+	pkgm += " update; sudo apt-get install -y "
 
 if len(pkgm) == 0:
 	pkgm = cmdline("which pacman 2>/dev/null").strip()
 	if len(pkgm) > 0:
-		pkgm += " -S "
+		pkgm += " -Syy; sudo pacman -S "
 
 
 if len(pkgm) == 0:
@@ -69,13 +70,17 @@ if len(pkgm) == 0:
 runpkg = 0
 run_pkg = ""
 
-if len(check_xbind) > 0 and len(check_xdotool) > 0:
-	print("Xbindkeys, and xdotool requirement is installed.")
+if len(check_xbind) > 0 and len(check_xdotool) > 0 and len(check_ibus) > 0:
+	print("Xbindkeys, xdotool and IBus requirement is installed.")
 if len(check_xbind) == 0:
 	run_pkg = "xbindkeys"
 	runpkg = 1
 if len(check_xdotool) == 0:
 	run_pkg += " xdotool"
+	runpkg = 1
+if len(check_ibus) == 0:
+	# may differ with distro, but for now
+	run_pkg += " ibus"
 	runpkg = 1
 
 if runpkg != 0:

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,12 @@ def requirements(pkgm):
 
 def install_ibus():
 	print(bcolors.CYELLOW + "You need to set IBus as the default Input Method for full word-wise support and re-run this installer.\n" + bcolors.ENDC)
+	print(bcolors.CYELLOW + "Confirm the IBus Setup by saying Yes and then closing the window.\n" + bcolors.ENDC)
+	print("ibus-setup\n")
 	print("im-config -n ibus\n")
 	run_install = yn_choice(bcolors.CYELLOW + "Would you like to run it now? (Will require logoff and logon.)\n" + bcolors.ENDC)
 	if(run_install):
+		os.system("ibus-setup")
 		os.system("im-config -n ibus")
 		print("\n")
 		input("IBus has been set as the default Input Method.\nPress any key to exit and re-run after logoff & logon...")

--- a/user_config.json
+++ b/user_config.json
@@ -36,7 +36,7 @@
         "symbols": "",
         "types": "",
         "de": [],
-        "appnames": [ "Chromium","Chromium-browser","Google-chrome" ]
+        "appnames": [ "Chromium","Chromium-browser","Google-chrome","Epiphany" ]
     }],
 	"init": [],
 	"detypes":["gnome2","gnome3","kde4","kde5","xfce","i3wm"],


### PR DESCRIPTION
Some distros need ibus-setup to run before IBus can be set as the default input method. Elementary browser Epiphany also added to the chrome app group for more complete shortcut support.