### PR TITLE
Change ibus install condition logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ if len(check_ibus) == 0:
 if runpkg != 0:
 	requirements(pkgm)
 
-if os.path.exists(homedir + '/.config/ibus/bus') and cmdline("ls ~/.config/ibus/bus -1rt") == "":
+os.makedirs(homedir + "/.config/ibus/bus", exist_ok=True)
+if cmdline("ls ~/.config/ibus/bus -1rt") == "":
 	install_ibus()
 
 


### PR DESCRIPTION
Since I'm comfortable with Python, I thought I could at least help out by taking a peek at the setup code and fixing an unofficially documented issue in #65 where ibus doesn't get setup on initial `./setup.py`.

I think the previous logic was incorrect in checking for the existence of `homedir + '/.config/ibus/bus'`. Instead, we want to create the local ibus parent directories since the goal is to prevent `ls: cannot access '~/.config/ibus/bus': No such file or directory`.

The issue where it doesn't run is likely not unique to Elementary OS, and as far as I can tell, going to affect at a minimum all Ubuntu-based distros because `apt-get install ibus -y` doesn't seem to create that directory.