### PR TITLE
Add Caps Lock to Escape modifier

### DIFF
--- a/.xkb/symbols/mac_gui
+++ b/.xkb/symbols/mac_gui
@@ -4,6 +4,10 @@ xkb_symbols "swapescape" {
     key <ESC>  { [ Caps_Lock ] };
 };
 hidden partial modifier_keys
+xkb_symbols "caps_escape" {
+    key <CAPS> { [ Escape ] };
+};
+hidden partial modifier_keys
 xkb_symbols "caps_shiftlock" {
     replace key <CAPS> { [ Shift_Lock ] };
     modifier_map Shift { Shift_Lock };


### PR DESCRIPTION
There already is "swapescape" which swaps caps lock with escape. I however don't use Caps Lock at all, and so far have bound it to Escape on all my systems. I think this can be useful for others as well. As it's only a couple of lines of code, I decided to put PR up.