### PR TITLE
Close streams and check fopen return in check_caret

### DIFF
--- a/kintox11/src/kintox11.c
+++ b/kintox11/src/kintox11.c
@@ -98,6 +98,9 @@ int check_caret(){
     char *buffer = NULL;
     size_t size = 0;
     FILE *fp = fopen(fpname, "r");
+    if (fp == NULL){
+        return (0);
+    }
     fseek(fp, 0, SEEK_END);
     size = ftell(fp);
     rewind(fp);
@@ -106,6 +109,7 @@ int check_caret(){
     buffer[size] = '\0';
     trimwhitespace(buffer);
     caretint = atoi(buffer);
+    fclose(fp);
     if(caretint == 1){
       // printf("caret: %s\n", buffer);
       return 1;


### PR DESCRIPTION
Previously, kintox11 would segfault after a while at line 101 (fseek) because fopen returned NULL with errno 24: Too many open files in check_caret.
This commit prevents fseek from crashing by checking the return value of fopen and prevents fopen from failing by closing the streams after we are done using them.