### PR TITLE
- Distro compatibility update for xkeysnail

### DIFF
--- a/system-config/unipkg.sh
+++ b/system-config/unipkg.sh
@@ -9,7 +9,7 @@ elif pkgmgr="$( which dnf )" 2> /dev/null; then
    $pkgmgr check-update; $pkgmgr install -y "$1"
 elif pkgmgr="$( which pacman )" 2> /dev/null; then
    echo "Arch-based"
-   $pkgmgr -Syy; $pkgmr -S "$1"
+   $pkgmgr -Syy; yes | pkgmr -S "$1"
 else
    echo "Package manager not found, please install $1" >&2
    exit 1

--- a/system-config/unipkg.sh
+++ b/system-config/unipkg.sh
@@ -9,7 +9,7 @@ elif pkgmgr="$( which dnf )" 2> /dev/null; then
    $pkgmgr check-update; $pkgmgr install -y "$1"
 elif pkgmgr="$( which pacman )" 2> /dev/null; then
    echo "Arch-based"
-   $pkgmgr -Syy; yes | pkgmr -S "$1"
+   $pkgmgr -Syy;yes | $pkgmgr -S "$1"
 else
    echo "Package manager not found, please install $1" >&2
    exit 1

--- a/system-config/unipkg.sh
+++ b/system-config/unipkg.sh
@@ -3,7 +3,7 @@
 if pkgmgr="$( which apt-get )" 2> /dev/null; then
    echo "Debian"
    $pkgmgr update
-   $pkgmgr install "$1"
+   $pkgmgr --yes --force-yes install "$1"
 elif pkgmgr="$( which dnf )" 2> /dev/null; then
    echo "dnf"
    $pkgmgr check-update; $pkgmgr install -y "$1"

--- a/xkeysnail-config/kinto.py
+++ b/xkeysnail-config/kinto.py
@@ -27,7 +27,7 @@ define_conditional_modmap(lambda wm_class: wm_class not in ("Gnome-terminal","ko
 })
 
 # [Conditional modmap] Change modifier keys in certain applications
-define_conditional_modmap(re.compile("Gnome-terminal|konsole|io.elementary.terminal|terminator|sakura|guake|tilda|xterm|eterm|kitty"), {
+define_conditional_modmap(re.compile("Gnome-terminal|konsole|Io.elementary.terminal|terminator|sakura|guake|tilda|xterm|eterm|kitty"), {
     # # Chromebook
     # Key.LEFT_ALT: Key.RIGHT_CTRL,     # Chromebook
     # # Left Ctrl Stays Left Ctrl
@@ -216,11 +216,19 @@ define_keymap(re.compile("konsole"),{
 
 }, "Konsole tab switching")
 
-define_keymap(re.compile("Gnome-terminal|konsole|io.elementary.terminal|terminator|sakura|guake|tilda|xterm|eterm|kitty"),{
+define_keymap(re.compile("Io.elementary.terminal"),{
     # Ctrl Tab - In App Tab Switching
-    K("LC-Tab") : K("LC-PAGE_DOWN"),
-    K("LC-Shift-Tab") : K("LC-PAGE_UP"),
-    K("LC-Grave") : K("LC-PAGE_UP"),
+    K("LC-Tab") : K("LC-Shift-Right"),
+    K("LC-Shift-Tab") : K("LC-Shift-Left"),
+    K("LC-Grave") : K("LC-Shift-Left"),
+
+}, "Elementary Terminal tab switching")
+
+define_keymap(re.compile("Gnome-terminal|konsole|Io.elementary.terminal|terminator|sakura|guake|tilda|xterm|eterm|kitty"),{
+    # Ctrl Tab - In App Tab Switching
+    # K("LC-Tab") : K("LC-PAGE_DOWN"),
+    # K("LC-Shift-Tab") : K("LC-PAGE_UP"),
+    # K("LC-Grave") : K("LC-PAGE_UP"),
     # Converts Cmd to use Ctrl-Shift
     K("RC-Tab"): K("RC-F13"),
     K("RC-Shift-Tab"): K("RC-Shift-F13"),

--- a/xkeysnail-config/prexk.sh
+++ b/xkeysnail-config/prexk.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-if systemctl -q --user is-enabled keyswap.timer; then
-	systemctl --user stop keyswap.timer
-	systemctl --user disable keyswap.timer
+if [ -f /home/{username}/.config/systemd/user/keyswap.timer ]; then
+	systemctl --user stop keyswap.timer >/dev/null 2>&1
+	systemctl --user disable keyswap.timer >/dev/null 2>&1
 fi
-if systemctl -q --user is-active keyswap; then
-	systemctl --user stop keyswap
-fi
-if systemctl -q --user is-enabled keyswap; then
-	systemctl --user disable keyswap
+if [ -f /home/{username}/.config/systemd/user/keyswap.service ]; then
+	systemctl --user stop keyswap >/dev/null 2>&1
+	systemctl --user disable keyswap >/dev/null 2>&1
 fi
 
 # export DISPLAY={displayid};/usr/bin/xhost +SI:localuser:root

--- a/xkeysnail-config/xkeystart.sh
+++ b/xkeysnail-config/xkeystart.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 # >/dev/null 2>&1
-/usr/local/bin/xkeysnail --quiet --watch "$1" &
+
+if [ -f /usr/local/bin/xkeysnail ];then
+	xkeyfullpath="/usr/local/bin/xkeysnail"
+elif [ -f /usr/bin/xkeysnail ];then
+	xkeyfullpath="/usr/bin/xkeysnail"
+else
+	xkeyfullpath=`which xkeysnail`
+fi
+
+"$xkeyfullpath" --quiet --watch "$1" &
 
 inotifywait -m -e close_write,moved_to,create,modify /tmp/kinto/xkeysnail |
+
 while read -r path; do
 	/usr/bin/killall xkeysnail
-	/usr/local/bin/xkeysnail --quiet --watch "$1" &
+	"$xkeyfullpath" --quiet --watch "$1" &
 done

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -169,16 +169,18 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 	mv ./xkeysnail-config/kinto.py.new ~/.config/kinto/kinto.py
 	# if [ "$distro" == "fedora" ];then
 	sudo rm /etc/systemd/system/xkeysnail.service
-	sudo mv ./xkeysnail-config/xkeysnail.service.new /usr/lib/systemd/system/xkeysnail.service
-	sudo chown -R root:root /usr/lib/systemd/system/xkeysnail.service
-	sudo chmod 644 /usr/lib/systemd/system/xkeysnail.service
-	sudo ln -s /usr/lib/systemd/system/xkeysnail.service /etc/systemd/system/xkeysnail.service
-	sudo ln -s /usr/lib/systemd/system/xkeysnail.service /etc/systemd/system/graphical.target.wants/xkeysnail.service
-	# else
-	#	sudo mv ./xkeysnail-config/xkeysnail.service.new /etc/systemd/system/xkeysnail.service 
-	#	sudo chown -R root:root /etc/systemd/system/xkeysnail.service
-	#	sudo chmod 644 /etc/systemd/system/xkeysnail.service
-	# fi
+	if [ -d /usr/lib/systemd/system ];then
+		echo "1"
+		xkeypath="/usr/lib/systemd/system/"
+	elif [ -d /lib/systemd/system ];then
+		echo "2"
+		xkeypath="/lib/systemd/system/"
+	fi
+	sudo mv ./xkeysnail-config/xkeysnail.service.new "$xkeypath"xkeysnail.service && echo "Service file added to "$xkeypath"xkeysnail.service"
+	sudo chown -R root:root "$xkeypath"xkeysnail.service && echo "Ownership set for root..." || echo "Failed to set ownership..."
+	sudo chmod 644 "$xkeypath"xkeysnail.service && echo "Permissions set to 644..." || echo "Failed to set permissions..."
+	sudo ln -s "$xkeypath"xkeysnail.service /etc/systemd/system/xkeysnail.service && echo "Created soft symlink..." || echo "Failed to create soft symlink..."
+	sudo ln -s "$xkeypath"xkeysnail.service /etc/systemd/system/graphical.target.wants/xkeysnail.service && echo "Created soft symlink for graphical target..." || echo "Failed to create soft symlink for graphical target..."
 	xhost +SI:localuser:root
 	git clone --depth 1 https://github.com/rbreaves/xkeysnail.git
 	cd xkeysnail
@@ -231,6 +233,7 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 	else
 		echo -e "Kinto \e[1m\e[91mxkeysnail service has failed.\e[0m"
 		echo "You can run 'sudo systemctl status xkeysnail' for more info"
+		echo "You can also run 'sudo journalctl -u xkeysnail'"
 	fi
 elif ! [[ $1 == "4" || $1 == "uninstall" ]]; then
 	echo "Expected argument was not provided"

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -3,6 +3,9 @@
 # set about:config?filter=ui.key.menuAccessKeyFocuses
 # to false for wordwise to work in Firefox
 
+typeset -l distro
+distro=$(awk -F= '$1=="NAME" { print $2 ;}' /etc/os-release)
+
 function uninstall {
 	typeset -l dename
 	dename=$(./system-config/dename.sh | cut -d " " -f1)
@@ -102,7 +105,17 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 		echo "Will need to install python3-pip..."
 		sudo ./system-config/unipkg.sh python3-pip
 	fi
-	
+	if ! [ -x "$(command -v python3-config)" ]; then
+		if [ "$distro" == "ubuntu" ] || [ "$distro" == "debian" ]; then
+			pydev="python3-dev"
+		elif [ "$distro" == "fedora" ]; then
+			pydev="python3-devel"
+		fi
+		if [ "$distro" == "gnome" ] || [ "$distro" == "fedora" ] || [ "$distro" == "debian" ]; then
+			echo "Will need to install $pydev..."
+			sudo ./system-config/unipkg.sh "$pydev"
+		fi
+	fi
 	# echo "Transferring files..."
 	mkdir -p ~/.config/kinto
 	
@@ -154,7 +167,18 @@ fi
 
 if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1 == "chromebook" ]]; then
 	mv ./xkeysnail-config/kinto.py.new ~/.config/kinto/kinto.py
-	sudo mv ./xkeysnail-config/xkeysnail.service.new /etc/systemd/system/xkeysnail.service 
+	# if [ "$distro" == "fedora" ];then
+	sudo rm /etc/systemd/system/xkeysnail.service
+	sudo mv ./xkeysnail-config/xkeysnail.service.new /usr/lib/systemd/system/xkeysnail.service
+	sudo chown -R root:root /usr/lib/systemd/system/xkeysnail.service
+	sudo chmod 644 /usr/lib/systemd/system/xkeysnail.service
+	sudo ln -s /usr/lib/systemd/system/xkeysnail.service /etc/systemd/system/xkeysnail.service
+	sudo ln -s /usr/lib/systemd/system/xkeysnail.service /etc/systemd/system/graphical.target.wants/xkeysnail.service
+	# else
+	#	sudo mv ./xkeysnail-config/xkeysnail.service.new /etc/systemd/system/xkeysnail.service 
+	#	sudo chown -R root:root /etc/systemd/system/xkeysnail.service
+	#	sudo chmod 644 /etc/systemd/system/xkeysnail.service
+	# fi
 	xhost +SI:localuser:root
 	git clone --depth 1 https://github.com/rbreaves/xkeysnail.git
 	cd xkeysnail
@@ -167,8 +191,13 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 	fi
 	git pull origin master
 	sudo pip3 install --upgrade .
-	sudo systemctl enable xkeysnail.service
 	sudo systemctl daemon-reload
+	sudo systemctl --state=not-found --all | grep xkeysnail
+	if [ "$distro" == "fedora" ];then
+		systemctl enable xkeysnail.service
+	else
+		sudo systemctl enable xkeysnail.service
+	fi
 	sudo systemctl restart xkeysnail
 
 	echo -e "Adding xhost fix...\n"
@@ -219,4 +248,10 @@ else
 	sudo rm /etc/sudoers.d/limitedadmins
 	rm ~/.config/autostart/xkeysnail.desktop
 	rm -rf ~/.config/kinto
+	sudo rm /etc/systemd/system/xkeysnail.service
+	sudo rm /etc/systemd/system/graphical.target.wants/xkeysnail.service
+	sudo rm /usr/lib/systemd/system/xkeysnail.service
+	sudo systemctl daemon-reload
+	sudo systemctl --state=not-found --all | grep xkeysnail
+	exit 0
 fi

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -116,6 +116,11 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 			sudo ./system-config/unipkg.sh "$pydev"
 		fi
 	fi
+	if ! [ -x "$(command -v xhost)" ]; then
+		if [ "$distro" == "\"manjaro linux\"" ]; then
+			sudo ./system-config/unipkg.sh xorg-xhost
+		fi
+	fi
 	# echo "Transferring files..."
 	mkdir -p ~/.config/kinto
 	
@@ -170,10 +175,8 @@ if [[ $1 == "1" || $1 == "2" || $1 == "3" || $1 == "winmac" || $1 == "mac" || $1
 	# if [ "$distro" == "fedora" ];then
 	sudo rm /etc/systemd/system/xkeysnail.service
 	if [ -d /usr/lib/systemd/system ];then
-		echo "1"
 		xkeypath="/usr/lib/systemd/system/"
 	elif [ -d /lib/systemd/system ];then
-		echo "2"
 		xkeypath="/lib/systemd/system/"
 	fi
 	sudo mv ./xkeysnail-config/xkeysnail.service.new "$xkeypath"xkeysnail.service && echo "Service file added to "$xkeypath"xkeysnail.service"


### PR DESCRIPTION
Tested install for KDE Neon, Elementary, Ubuntu, Pop OS, and Manjaro. Fedora not working.