### PR TITLE
Make toggle-application-view shortcut more mac like

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ def setShortcuts():
 			cmdline("gsettings set org.gnome.desktop.wm.keybindings minimize \"['<Super>h','<Alt>F9']\"")
 			cmdline("gsettings set org.gnome.desktop.wm.keybindings panel-main-menu \"['<Primary><Shift>Space','<Primary>Space']\"")
 			cmdline("gsettings set org.gnome.mutter overlay-key ''")
+			cmdline("gsettings set org.gnome.shell.keybindings toggle-application-view \"['LaunchB']\"")
 		if distro == "ubuntu" and dename == "gnome":
 			cmdline("gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-up \"['<Super>Up','<Super>Left']\"")
 			cmdline("gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-down \"['<Super>Down','<Super>Right']\"")


### PR DESCRIPTION
Toggle-application-view defaults to `<Super-a>` (virtual)/`<Ctrl-a>` (physical)
This clashed with using `<Ctrl-a>`(physical) for move cursor to beginning of
line (OS/X).
`LaunchB` seems the closes OS/X analogue - FN-F4 on a mac keyboard.