### PR TITLE
Fixing Alt + Backspace on Windows

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -258,7 +258,7 @@ $^+Right::Send +{End}
 ^+Up::Send ^+{Home}
 ^Down::Send ^{End}
 ^+Down::Send ^+{End}
-^Backspace::Send +{Home}{Delete}
+$^Backspace::Send +{Home}{Delete}
 !Backspace::Send ^{Backspace}
 !Left::Send ^{Left}
 !+Left::Send ^+{Left}
@@ -303,7 +303,7 @@ $^+Right::Send +{End}
     #+q::Send !q                    ;Context info
     #!o::Send ^!o                   ;Optimize imports
     #!i::Send ^!i                   ;Auto-indent line(s)
-    ^Backspace::Send ^y             ;Delete line at caret
+    $^Backspace::Send ^y             ;Delete line at caret
     #+j::Send ^+j                   ;Smart line join
     !Delete::Send ^{Delete}         ;Delete to word end
     !Backspace::Send ^{Backspace}   ;Delete to word start


### PR DESCRIPTION
Just a quick fix for the autohotkey script so that `ctrl + backspace` is only accepted if it's a "raw" input from the keyboard to prevent `alt + backspace` from triggering it and causing you delete the whole line when you just wanted to delete a word.
