### PR TITLE
- Fixes copy/paste for cmd/mintty in Win10

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -111,6 +111,9 @@ GroupAdd, ConEmu, ahk_exe ConEmu.exe
 GroupAdd, ConEmu, ahk_exe ConEmu64.exe
 GroupAdd, ConEmu, ahk_exe WindowsTerminal.exe
 
+GroupAdd, ExcPaste, ahk_exe Cmd.exe
+GroupAdd, ExcPaste, ahk_exe mintty.exe
+
 GroupAdd, editors, ahk_exe sublime_text.exe
 GroupAdd, editors, ahk_exe VSCodium.exe
 GroupAdd, editors, ahk_exe Code.exe
@@ -446,31 +449,45 @@ GroupAdd, intellij, ahk_exe idea64.exe
     #IfWinActive ahk_group terminals
 
         ; End of Line
-        #e::
+        #e:: ; Default
+        ; !e:: ; CB/IBM
         Send {End}
         return
 
         ; Beginning of Line
-        #a::
+        #a:: ; Default
+        ; !a:: ; CB/IBM
         Send {Home}
         return
 
         ; Copy
         ^c::
-        SetKeyDelay -1
-        Send {Blind}{LShift down}{c DownTemp}
+        If WinActive("ahk_exe cmd.exe"){
+            Send {Enter}
+        }
+        else if WinActive("ahk_exe mintty.exe"){
+            SetKeyDelay -1
+            Send {Blind}{Insert}
+        }
+        else{
+            SetKeyDelay -1
+            Send {Blind}{LShift down}{c DownTemp}
+        }
         return
 
         ^c up::
-        SetKeyDelay -1
-        Send {Blind}{c Up}{LShift Up}
+        If not WinActive("ahk_group cmd.exe"){
+            SetKeyDelay -1
+            Send {Blind}{c Up}{LShift Up}
+        }
         return
 
         ; Sigints - interrupt
-        $#c::Send {Ctrl down}c{Ctrl up}
+        $#c::Send {Ctrl down}c{Ctrl up} ; Default
+        ; $!c::Send {Ctrl down}c{Ctrl up} ; CB/IBM
 
         ; Paste
-        ^v::
+        $^v::
         If WinActive("ahk_exe mintty.exe"){
             Send {Shift down}{Insert}{Shift up}
         }


### PR DESCRIPTION
Be careful of a potential merge conflict or undoing of the "; Default" option of terminals for Windows when Alpha finally goes live.