### PR TITLE
Add Hyper terminal to Linux

### DIFF
--- a/xkeysnail-config/kinto.py
+++ b/xkeysnail-config/kinto.py
@@ -7,7 +7,7 @@ from xkeysnail.transform import *
 # Use the following for testing terminal keymaps
 # terminals = [ "", ... ]
 # xbindkeys -mk
-terminals = ["kinto-gui.py","gnome-terminal","konsole","io.elementary.terminal","terminator","sakura","guake","tilda","xterm","eterm","kitty","alacritty","mate-terminal","tilix","xfce4-terminal"]
+terminals = ["kinto-gui.py","gnome-terminal","konsole","io.elementary.terminal","terminator","sakura","guake","tilda","xterm","eterm","kitty","alacritty","mate-terminal","tilix","xfce4-terminal","hyper"]
 terminals = [term.casefold() for term in terminals]
 termStr = "|".join(str(x) for x in terminals)
 


### PR DESCRIPTION
Recently stumbled upon this tool to use the Mac keyboard under Linux and Windows. It works great!

Hyper (https://hyper.is/) is already added for Windows, not so for Linux!