### PR TITLE
Catch all Jetbrains applications

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -107,7 +107,7 @@ define_conditional_modmap(re.compile(termStr, re.IGNORECASE), {
 })
 
 # Keybindings for IntelliJ
-define_keymap(re.compile("jetbrains-idea", re.IGNORECASE),{
+define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
     # General
     K("C-Key_0"): K("M-Key_0"),                 # Open corresponding tool window
     K("C-Key_1"): K("M-Key_1"),                 # Open corresponding tool window


### PR DESCRIPTION
Right now, only IntelliJ IDEA IDE is being remapped. However, if you try to use CLion, PyCharm, etc. those won't be remapped as they have a different `WM_CLASS` value, for example: `jetbrains-clion`, `jetbrains-pycharm`, etc.

This PR just adds a wildcard to the regular expression for jetbrains remapping to catch all IDEs, but excluding the Jetbrains Toolbox app, which does not need remapping.

Tested with CLion, IntelliJ, PyCharm and Android Studio. Not sure if this will catch 100% of availables IDEs in Linux (for example, others like MPS, Datalore, etc.)