### PR TITLE
Make Command+Num on linux jump to tabs in browsers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -209,6 +209,15 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Q"): K("RC-Q"),           # Close all browsers Instances
     K("M-RC-I"): K("RC-Shift-I"),   # Dev tools
     K("M-RC-J"): K("RC-Shift-J"),   # Dev tools
+    K("RC-Key_1"): K("M-Key_1"),    # Jump to Tab #1-#8
+    K("RC-Key_2"): K("M-Key_2"),
+    K("RC-Key_3"): K("M-Key_3"),
+    K("RC-Key_4"): K("M-Key_4"),
+    K("RC-Key_5"): K("M-Key_5"),
+    K("RC-Key_6"): K("M-Key_6"),
+    K("RC-Key_7"): K("M-Key_7"),
+    K("RC-Key_8"): K("M-Key_8"),
+    K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
 })
 
 # Open preferences in browsers


### PR DESCRIPTION
See "Go to Tab 1 to 8" and "Go to Last Tab":

https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly#w_windows-tabs

See "Jump to a specific tab" and "Jump to the rightmost tab":

https://support.google.com/chrome/answer/157179?co=GENIE.Platform%3DDesktop&hl=en#zippy=%2Ctab-and-window-shortcuts

I tested this on Ubuntu with an Apple keyboard on Chromium and Firefox, but I'm not sure how it behaves on the rest of the things in `browserStr`