### PR TITLE
Fix Command + Shift + Grave same app switching so it moves backwards, not forwards

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -232,7 +232,7 @@ define_keymap(None,{
     K("RC-Tab"): K("M-Tab"),                      # Default not-xfce4 - Cmd Tab - App Switching Default
     K("RC-Shift-Tab"): K("M-Shift-Tab"),          # Default not-xfce4 - Cmd Tab - App Switching Default
     K("RC-Grave"): K("M-Grave"),                  # Default not-xfce4 - Cmd ` - Same App Switching
-    K("RC-Shift-Grave"): K("M-Grave"),            # Default not-xfce4 - Cmd ` - Same App Switching
+    K("RC-Shift-Grave"): K("M-Shift-Grave"),      # Default not-xfce4 - Cmd ` - Same App Switching
     # K("Super-Right"):K("Super-Page_Up"),          # SL - Change workspace (ubuntu/fedora)
     # K("Super-Left"):K("Super-Page_Down"),         # SL - Change workspace (ubuntu/fedora)
     # K("Super-Right"):K("Super-C-Up"),             # SL - Change workspace (popos)


### PR DESCRIPTION
On Ubuntu 18 I noticed that I can press Command + Grave and switch between windows belonging to the same app, but holding Shift didn't make them move backwards.  This might have just been a copypasta mistake from the line above?