### PR TITLE
temporary fix for using kinto with Synergy

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -44,6 +44,12 @@ define_multipurpose_modmap(
     {                                         # Placeholder
 })
 
+# Fix for avoiding modmapping when using Synergy keyboard/mouse sharing.
+# Synergy doesn't set a wm_class, so this may cause issues with other
+# applications that also don't set the wm_class.
+# Enable only if you use Synergy.
+# define_conditional_modmap(lambda wm_class: wm_class == '', {})
+
 # [Global modemap] Change modifier keys as in xmodmap
 define_conditional_modmap(lambda wm_class: wm_class.casefold() not in terminals,{
 


### PR DESCRIPTION
If you use kinto and [Synergy](https://symless.com/synergy) at the same time, kinto will apply transformations when Synergy has the focus. This messes up input because the transformed keypresses are consumed by a different desktop than the one kinto is running on.

However it is not possible to write a rule to avoid transforming keypresses specifically for Synergy, because Synergy doesn't seem to set the wm_class.

The  conditional modmap in this commit solves the problem. But it will also affect any other applications not setting the wm_class. For this, the modmap is commented by default, and Synergy users (which shouldn't be too many) need to enable it manually.

 The fix is considered temporary. I have contacted the Synergy team separately, explaining the issue and asking them to set an appropriate wm_class.