### PR TITLE
Fix "toggle maximization state" shortcut for gnome/kde

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -251,7 +251,7 @@ define_keymap(re.compile(chromeStr, re.IGNORECASE),{
 define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
     K("RC-Space"): K("Alt-F1"),                   # Default SL - Launch Application Menu (gnome/kde)
     K("RC-F3"):K("Super-d"),                      # Default SL - Show Desktop (gnome/kde,eos)
-    K("RC-LC-f"):K("M-F10"),                      # Default SL - Maximize app (gnome/kde)
+    K("RC-Super-f"):K("M-F10"),                      # Default SL - Maximize app (gnome/kde)
     # K("Super-Right"):K("C-M-Right"),              # Default SL - Change workspace (budgie)
     # K("Super-Left"):K("C-M-Left"),                # Default SL - Change workspace (budgie)
     K("RC-Q"): K("M-F4"),                         # Default SL - not-popos


### PR DESCRIPTION
Changed "LC" to "Super" to fix the "toggle maximization state" shortcut. [ K("RC-Super-f"):K("M-F10"), ]
Not changing the other three instances, not sure if they need to be changed. (eos, manjaro, manjaro)