### PR TITLE
Finder mods for common Linux file managers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -239,7 +239,7 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
 
 # Keybindings overrides for elementary OS Files 
 # (overrides some bindings from general file browser code block below)
-define_keymap(re.compile("io.elementary.Files", re.IGNORECASE),{
+define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
     K("RC-Shift-T"): K("Shift-Enter"),          # Open folder in new tab
     K("RC-Comma"): None,                        # Disable preferences shortcut since none availabe
 })
@@ -286,7 +286,7 @@ define_keymap(re.compile("thunar", re.IGNORECASE),{
 # SpaceFM (Fork of PCManFM file manager)
 # Thunar File Manager (Xfce file manager)
 # 
-define_keymap(re.compile("caja|dolphin|io.elementary.Files|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
+define_keymap(re.compile("caja|dolphin|io.elementary.files|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
     K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
     K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
     K("RC-Up"): K("M-Up"),                  # Go Up dir
@@ -297,8 +297,8 @@ define_keymap(re.compile("caja|dolphin|io.elementary.Files|nemo|org.gnome.Nautil
     K("RC-Shift-o"): K("RC-Shift-o"),       # Open in new window
     K("RC-Left"): K("M-Left"),              # Go Back
     K("RC-Right"): K("M-Right"),            # Go Forward
-    K("Enter"): K("F2"),				    # Rename with Enter key
-    K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
+    # K("Enter"): K("F2"),				    # Rename with Enter key
+    # K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
     K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
     K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
     K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -294,19 +294,33 @@ define_keymap(re.compile("thunar", re.IGNORECASE),{
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
 })
 
+filemanagers = [
+    "caja",
+    "dolphin",
+    "io.elementary.files",
+    "nemo",
+    "org.gnome.Nautilus",
+    "pcmanfm",
+    "pcmanfm-qt",
+    "spacefm",
+    "thunar",
+    ]
+filemanagers = [filemanager.casefold() for filemanager in filemanagers]
+filemanagerStr = "|".join(str(x) for x in filemanagers)
+
 # Keybindings for general file browsers group: 
 # 
 # Caja File Browser (MATE file manager, fork of Nautilus)
 # Dolphin (KDE file manager)
-# elementary OS Files (eOS file manager, fork of Nautilus)
 # Nautilus (GNOME file manager, may be called "Files")
 # Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
+# Pantheon Files (eOS file manager, fork of Nautilus)
 # PCManFM (LXDE file manager)
 # PCManFM-Qt (LXQt file manager)
 # SpaceFM (Fork of PCManFM file manager)
 # Thunar File Manager (Xfce file manager)
 # 
-define_keymap(re.compile("caja|dolphin|io.elementary.files|nemo|org.gnome.Nautilus|pcmanfm|pcmanfm-qt|spacefm|thunar", re.IGNORECASE),{
+define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
     K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
     K("RC-Up"): K("M-Up"),                  # Go Up dir

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -7,7 +7,26 @@ from xkeysnail.transform import *
 # Use the following for testing terminal keymaps
 # terminals = [ "", ... ]
 # xbindkeys -mk
-terminals = ["kinto-gui.py","gnome-terminal","konsole","io.elementary.terminal","terminator","sakura","guake","tilda","xterm","eterm","kitty","alacritty","mate-terminal","tilix","xfce4-terminal","hyper"]
+terminals = [
+    "alacritty",
+    "eterm",
+    "gnome-terminal",
+    "guake",
+    "hyper",
+    "io.elementary.terminal",
+    "kinto-gui.py",
+    "kitty",
+    "konsole",
+    "mate-terminal",
+    "qterminal",
+    "sakura",
+    "terminator",
+    "tilda",
+    "tilix",
+    "xfce4-terminal",
+    "xterm",
+]
+
 terminals = [term.casefold() for term in terminals]
 termStr = "|".join(str(x) for x in terminals)
 

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -7,26 +7,7 @@ from xkeysnail.transform import *
 # Use the following for testing terminal keymaps
 # terminals = [ "", ... ]
 # xbindkeys -mk
-terminals = [
-    "alacritty",
-    "eterm",
-    "gnome-terminal",
-    "guake",
-    "hyper",
-    "io.elementary.terminal",
-    "kinto-gui.py",
-    "kitty",
-    "konsole",
-    "mate-terminal",
-    "qterminal",
-    "sakura",
-    "terminator",
-    "tilda",
-    "tilix",
-    "xfce4-terminal",
-    "xterm",
-]
-
+terminals = ["kinto-gui.py","gnome-terminal","konsole","io.elementary.terminal","terminator","sakura","guake","tilda","xterm","eterm","kitty","alacritty","mate-terminal","tilix","xfce4-terminal","hyper"]
 terminals = [term.casefold() for term in terminals]
 termStr = "|".join(str(x) for x in terminals)
 
@@ -36,10 +17,7 @@ codeStr = "|".join(str(x) for x in mscodes)
 # Add remote desktop clients & VM software here
 # Ideally we'd only exclude the client window,
 # but that may not be easily done.
-remotes = [
-    "org.remmina.Remmina",
-    "xfreerdp",
-]
+remotes = ["org.remmina.Remmina","xfreerdp"]
 remotes = [client.casefold() for client in remotes]
 
 # Add remote desktop clients & VMs for no remapping
@@ -47,26 +25,11 @@ terminals.extend(remotes)
 mscodes.extend(remotes)
 
 # Use for browser specific hotkeys
-browsers = [
-    "Chromium",
-    "Chromium-browser",
-    "Discord",
-    "Epiphany",
-    "Firefox",
-    "Google-chrome",
-    "microsoft-edge",
-    "microsoft-edge-dev",
-]
+browsers = ["Chromium","Chromium-browser","Google-chrome","microsoft-edge-dev","microsoft-edge","Epiphany","Firefox","Discord"]
 browsers = [browser.casefold() for browser in browsers]
 browserStr = "|".join(str(x) for x in browsers)
 
-chromes = [
-    "Chromium",
-    "Chromium-browser",
-    "Google-chrome",
-    "microsoft-edge",
-    "microsoft-edge-dev",
-]
+chromes = ["Chromium","Chromium-browser","Google-chrome","microsoft-edge-dev","microsoft-edge"]
 chromes = [chrome.casefold() for chrome in chromes]
 chromeStr = "|".join(str(x) for x in chromes)
 
@@ -380,12 +343,7 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
 
 # Open preferences in browsers
 define_keymap(re.compile("Firefox", re.IGNORECASE),{
-    K("C-comma"): [
-        K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),
-        K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),
-        K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")
-    ],
-})
+    K("C-comma"): [K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")],)
 define_keymap(re.compile(chromeStr, re.IGNORECASE),{
     K("C-comma"): [K("M-e"), K("s"),K("Enter")],
 })

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -219,14 +219,14 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 # Keybindings overrides for Caja 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("caja", re.IGNORECASE),{
-    K("RC-Shift-T"): K("RC-Shift-Enter"),   # Open folder/file in new tab 
-    K("RC-Shift-o"): K("RC-Shift-W"),       # Open folder/file in new window
+    K("RC-Shift-T"): K("RC-Shift-Enter"),   # Open folder in new tab 
+    K("RC-Shift-o"): K("RC-Shift-W"),       # Open folder in new window
 })
 
 # Keybindings overrides for Dolphin 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("dolphin", re.IGNORECASE),{
-    K("RC-Shift-o"): K("RC-Shift-Enter"), # Open folder/file in new window 
+    K("RC-Shift-o"): K("RC-Shift-Enter"), # Open folder in new window 
     # "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+Enter 
     # in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.)
     ### 
@@ -237,11 +237,18 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
 })
 
+# Keybindings overrides for elementary OS Files 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("io.elementary.Files", re.IGNORECASE),{
+    K("RC-Shift-T"): K("Shift-Enter"),          # Open folder in new tab
+    K("RC-Comma"): None,                        # Disable preferences shortcut since none availabe
+})
+
 # Keybindings overrides for Nautilus 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("org.gnome.Nautilus", re.IGNORECASE),{
-    K("RC-Shift-o"): K("Shift-Enter"),           # Open folder/file in new window
-    K("RC-Shift-T"): K("RC-Enter"),                 # Open folder/file in new tab
+    K("RC-Shift-o"): K("Shift-Enter"),           # Open in new window
+    K("RC-Shift-T"): K("RC-Enter"),                 # Open in new tab
     K("RC-comma"): K("RC-comma"),                   # Overrides "Open preferences dialog" shortcut below
 })
 
@@ -264,7 +271,7 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
 # Keybindings overrides for Thunar 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
-    K("RC-Shift-T"): K("RC-Shift-P"),          # Open folder/file in new tab
+    K("RC-Shift-T"): K("RC-Shift-P"),          # Open in new tab
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
 })
 
@@ -272,27 +279,26 @@ define_keymap(re.compile("thunar", re.IGNORECASE),{
 # 
 # Caja File Browser (MATE file manager, fork of Nautilus)
 # Dolphin (KDE file manager)
+# elementary OS Files (eOS file manager, fork of Nautilus)
 # Nautilus (GNOME file manager, may be called "Files")
 # Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
 # PCManFM (LXDE/LXQt file manager)
 # SpaceFM (Fork of PCManFM file manager)
 # Thunar File Manager (Xfce file manager)
 # 
-define_keymap(re.compile("caja|dolphin|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
+define_keymap(re.compile("caja|dolphin|io.elementary.Files|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
     K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
     K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
     K("RC-Up"): K("M-Up"),                  # Go Up dir
     # K("RC-Down"): K("M-Down"),            # Go Down dir (only works on folders)
     # K("RC-Down"): K("RC-O"),              # Go Down dir (open folder/file)
     K("RC-Down"): K("Enter"),               # Go Down dir (open folder/file)
-    # K("RC-Shift-Down"): K("RC-Shift-o"),  # Open folder/file in new window (doesn't match Finder)
-    K("RC-Shift-o"): K("RC-Shift-o"),       # Open folder/file in new window
+    # K("RC-Shift-Down"): K("RC-Shift-o"),  # Open in new window (doesn't match Finder)
+    K("RC-Shift-o"): K("RC-Shift-o"),       # Open in new window
     K("RC-Left"): K("M-Left"),              # Go Back
     K("RC-Right"): K("M-Right"),            # Go Forward
-    # To enable renaming files with the Enter key, uncomment the two lines just below. 
-    # Use Ctrl+Shift+Enter to escape or activate text fields. 
-    # K("Enter"): K("F2"),				    # Rename with Enter key
-    # K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
+    K("Enter"): K("F2"),				    # Rename with Enter key
+    K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
     K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
     K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
     K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)
@@ -579,7 +585,6 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     # K("RC-Shift-Tab"): K("RC-Shift-backslash"),   # xfce4
     # K("RC-Grave"): K("RC-Shift-backslash"),       # xfce4
     # Converts Cmd to use Ctrl-Shift
-    K("RC-V"): K("C-Shift-V"),
     K("RC-MINUS"): K("C-Shift-MINUS"),
     K("RC-EQUAL"): K("C-Shift-EQUAL"),
     K("RC-BACKSPACE"): K("C-Shift-BACKSPACE"),

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -392,7 +392,7 @@ define_keymap(re.compile(chromeStr, re.IGNORECASE),{
 # Opera C-F12
 
 define_keymap(re.compile(termStr, re.IGNORECASE),{
-    K("RC-Dot"): K("LC-C"),                         # Map Ctrl+Dot to Ctrl+C in terminals
+    K("RC-Dot"): K("LC-c"),                         # Map Ctrl+Dot to Ctrl+C in terminals
 }, "Mapping Ctrl+Dot to Ctrl+C in terminals")
 
 # None referenced here originally
@@ -466,11 +466,13 @@ define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
     K("RC-Shift-Up"): K("C-Shift-Home"),          # Select all to Beginning of File
     K("RC-Down"): K("C-End"),                     # End of File
     K("RC-Shift-Down"): K("C-Shift-End"),         # Select all to End of File
-    # K("M-Backspace"): K("Delete"),                # Chromebook/IBM - Delete
-    K("Super-Backspace"): K("C-Backspace"),       # Default not-chromebook - Delete Left Word of Cursor
-    K("Super-Delete"): K("C-Delete"),             # Default not-chromebook - Delete Right Word of Cursor
-    K("Alt-Backspace"): K("C-Backspace"),         # Default not-chromebook - Delete Left Word of Cursor
-    K("Alt-Delete"): K("C-Delete"),               # Default not-chromebook - Delete Right Word of Cursor
+    # K("RM-Backspace"): K("Delete"),               # Chromebook/IBM - Delete
+    K("Super-Backspace"): K("C-Backspace"),       # Delete Left Word of Cursor
+    K("Super-Delete"): K("C-Delete"),             # Delete Right Word of Cursor
+    # K("LM-Backspace"): K("C-Backspace"),          # Chromebook/IBM - Delete Left Word of Cursor
+    K("M-Backspace"): K("C-Backspace"),           # Default not-chromebook
+    K("RC-Backspace"): K("C-Shift-Backspace"),    # Delete Entire Line Left of Cursor
+    K("Alt-Delete"): K("C-Delete"),               # Delete Right Word of Cursor
     # K(""): pass_through_key,                      # cancel
     # K(""): K(""),                                 #
 })
@@ -682,6 +684,7 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     K("RC-M"): K("C-Shift-M"),
     K("RC-COMMA"): K("C-Shift-COMMA"),
     # K("RC-DOT"): K("C-Shift-DOT"),
+    K("RC-Dot"): K("LC-c"),
     K("RC-SLASH"): K("C-Shift-SLASH"),
     K("RC-KPASTERISK"): K("C-Shift-KPASTERISK"),
 }, "terminals")

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -350,15 +350,10 @@ define_keymap(re.compile(chromeStr, re.IGNORECASE),{
 })
 # Opera C-F12
 
-define_keymap(re.compile(termStr, re.IGNORECASE),{
-    K("RC-Dot"): K("LC-c"),                         # Map Ctrl+Dot to Ctrl+C in terminals
-}, "Mapping Ctrl+Dot to Ctrl+C in terminals")
-
 # None referenced here originally
 # - but remote clients and VM software ought to be set here
 # These are the typical remaps for ALL GUI based apps
 define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
-    K("RC-Dot"): K("Esc"),                          # Mimic macOS Cmd+dot = Escape key (not in terminals)
     K("RC-Space"): K("Alt-F1"),                   # Default SL - Launch Application Menu (gnome/kde)
     K("RC-F3"):K("Super-d"),                      # Default SL - Show Desktop (gnome/kde,eos)
     K("RC-Super-f"):K("M-F10"),                      # Default SL - Maximize app (gnome/kde)
@@ -607,6 +602,7 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     # K("RC-Shift-Tab"): K("RC-Shift-backslash"),   # xfce4
     # K("RC-Grave"): K("RC-Shift-backslash"),       # xfce4
     # Converts Cmd to use Ctrl-Shift
+    K("RC-V"): K("C-Shift-V"),
     K("RC-MINUS"): K("C-Shift-MINUS"),
     K("RC-EQUAL"): K("C-Shift-EQUAL"),
     K("RC-BACKSPACE"): K("C-Shift-BACKSPACE"),
@@ -642,8 +638,7 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     K("RC-N"): K("C-Shift-N"),
     K("RC-M"): K("C-Shift-M"),
     K("RC-COMMA"): K("C-Shift-COMMA"),
-    # K("RC-DOT"): K("C-Shift-DOT"),
-    K("RC-Dot"): K("LC-c"),
+    K("RC-DOT"): K("C-Shift-DOT"),
     K("RC-SLASH"): K("C-Shift-SLASH"),
     K("RC-KPASTERISK"): K("C-Shift-KPASTERISK"),
 }, "terminals")

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -282,11 +282,12 @@ define_keymap(re.compile("thunar", re.IGNORECASE),{
 # elementary OS Files (eOS file manager, fork of Nautilus)
 # Nautilus (GNOME file manager, may be called "Files")
 # Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
-# PCManFM (LXDE/LXQt file manager)
+# PCManFM (LXDE file manager)
+# PCManFM-Qt (LXQt file manager)
 # SpaceFM (Fork of PCManFM file manager)
 # Thunar File Manager (Xfce file manager)
 # 
-define_keymap(re.compile("caja|dolphin|io.elementary.files|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
+define_keymap(re.compile("caja|dolphin|io.elementary.files|nemo|org.gnome.Nautilus|pcmanfm|pcmanfm-qt|spacefm|thunar", re.IGNORECASE),{
     K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
     K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
     K("RC-Up"): K("M-Up"),                  # Go Up dir

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -212,13 +212,95 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
     K("Super-c"): K("LC-c"),                    # Sigints - interrupt
 })
 
-# Keybindings for Nautilus
-define_keymap(re.compile("org.gnome.nautilus", re.IGNORECASE),{
-    K("RC-Up"): K("M-Up"),          # Go Up dir
-    K("RC-Down"): K("M-Down"),      # Go Down dir
-    K("RC-Left"): K("M-Left"),      # Go Back
-    K("RC-Right"): K("M-Right"),    # Go Forward
+##########################################
+# START OF FILE MANAGER GROUP OF KEYMAPS #
+##########################################
+
+# Keybindings overrides for Caja 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("caja", re.IGNORECASE),{
+    K("RC-Shift-T"): K("RC-Shift-Enter"),   # Open folder/file in new tab 
+    K("RC-Shift-o"): K("RC-Shift-W"),       # Open folder/file in new window
 })
+
+# Keybindings overrides for Dolphin 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("dolphin", re.IGNORECASE),{
+    K("RC-Shift-o"): K("RC-Shift-Enter"), # Open folder/file in new window 
+    # "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+Enter 
+    # in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.)
+    ### 
+    # "Open in new tab" requires manually setting custom shortcut of Ctrl+Shift+T in 
+    # Dolphin's keyboard shortcuts. This conflicts with and replaces "Undo close tab".
+    ### 
+    K("RC-Shift-N"): K("F10"),                  # Create new folder
+    K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
+})
+
+# Keybindings overrides for Nautilus 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("org.gnome.Nautilus", re.IGNORECASE),{
+    K("RC-Shift-o"): K("Shift-Enter"),           # Open folder/file in new window
+    K("RC-Shift-T"): K("RC-Enter"),                 # Open folder/file in new tab
+    K("RC-comma"): K("RC-comma"),                   # Overrides "Open preferences dialog" shortcut below
+})
+
+# Keybindings overrides for PCManFM 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("pcmanfm", re.IGNORECASE),{
+    K("RC-Backspace"): [K("Delete"),K("Enter")],    # Move to Trash (delete, bypass dialog)
+})
+
+# Keybindings overrides for SpaceFM
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("spacefm", re.IGNORECASE),{
+    K("RC-Shift-N"): [K("RC-F")],	                # Create new folder is Ctrl+F by default
+    K("RC-Backspace"): [K("Delete"),K("Enter")],	# Move to Trash (delete, bypass dialog)
+    K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
+    # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences. 
+    # SpaceFM seems to be doing some nasty binding that blocks things like Alt+Tab while the menu is open. 
+})
+
+# Keybindings overrides for Thunar 
+# (overrides some bindings from general file browser code block below)
+define_keymap(re.compile("thunar", re.IGNORECASE),{
+    K("RC-Shift-T"): K("RC-Shift-P"),          # Open folder/file in new tab
+    K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
+})
+
+# Keybindings for general file browsers group: 
+# 
+# Caja File Browser (MATE file manager, fork of Nautilus)
+# Dolphin (KDE file manager)
+# Nautilus (GNOME file manager, may be called "Files")
+# Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
+# PCManFM (LXDE/LXQt file manager)
+# SpaceFM (Fork of PCManFM file manager)
+# Thunar File Manager (Xfce file manager)
+# 
+define_keymap(re.compile("caja|dolphin|nemo|org.gnome.Nautilus|pcmanfm|spacefm|thunar", re.IGNORECASE),{
+    K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
+    K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
+    K("RC-Up"): K("M-Up"),                  # Go Up dir
+    # K("RC-Down"): K("M-Down"),            # Go Down dir (only works on folders)
+    # K("RC-Down"): K("RC-O"),              # Go Down dir (open folder/file)
+    K("RC-Down"): K("Enter"),               # Go Down dir (open folder/file)
+    # K("RC-Shift-Down"): K("RC-Shift-o"),  # Open folder/file in new window (doesn't match Finder)
+    K("RC-Shift-o"): K("RC-Shift-o"),       # Open folder/file in new window
+    K("RC-Left"): K("M-Left"),              # Go Back
+    K("RC-Right"): K("M-Right"),            # Go Forward
+    # To enable renaming files with the Enter key, uncomment the two lines just below. 
+    # Use Ctrl+Shift+Enter to escape or activate text fields. 
+    # K("Enter"): K("F2"),				    # Rename with Enter key
+    # K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
+    K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
+    K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
+    K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)
+})
+
+########################################
+# END OF FILE MANAGER GROUP OF KEYMAPS #
+########################################
 
 # Keybindings for Browsers
 define_keymap(re.compile(browserStr, re.IGNORECASE),{

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -221,7 +221,7 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 define_keymap(re.compile("caja", re.IGNORECASE),{
     # K("RC-Super-o"): K("RC-Shift-Enter"),   # Open in new tab 
     K("RC-Super-o"): K("RC-Shift-W"),       # Open in new window
-})
+},"Overrides_Caja")
 
 # Keybindings overrides for Dolphin 
 # (overrides some bindings from general file browser code block below)
@@ -235,14 +235,14 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     ### 
     K("RC-Shift-N"): K("F10"),                  # Create new folder
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
-})
+},"Overrides_Dolphin")
 
 # Keybindings overrides for elementary OS Files 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
     # K("RC-Super-o"): K("Shift-Enter"),          # Open folder in new tab
     K("RC-Comma"): None,                        # Disable preferences shortcut since none availabe
-})
+},"Overrides_Pantheon")
 
 # Keybindings overrides for Nautilus 
 # (overrides some bindings from general file browser code block below)
@@ -250,13 +250,13 @@ define_keymap(re.compile("org.gnome.Nautilus", re.IGNORECASE),{
     K("RC-Super-o"): K("Shift-Enter"),           # Open in new window
     # K("RC-Super-o"): K("RC-Enter"),                 # Open in new tab
     K("RC-comma"): K("RC-comma"),                   # Overrides "Open preferences dialog" shortcut below
-})
+},"Overrides_Nautilus")
 
 # Keybindings overrides for PCManFM 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("pcmanfm", re.IGNORECASE),{
     K("RC-Backspace"): [K("Delete"),K("Enter")],    # Move to Trash (delete, bypass dialog)
-})
+},"Overrides_PCManFM")
 
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file browser code block below)
@@ -266,14 +266,14 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
     K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
     # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences. 
     # SpaceFM seems to be doing some nasty binding that blocks things like Alt+Tab while the menu is open. 
-})
+},"Overrides_SpaceFM")
 
 # Keybindings overrides for Thunar 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
     K("RC-Super-o"): K("RC-Shift-P"),          # Open in new tab
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
-})
+},"Overrides_Thunar")
 
 filemanagers = [
     "caja",
@@ -319,7 +319,7 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
     K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
     K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)
-})
+},"File_Managers")
 
 ########################################
 # END OF FILE MANAGER GROUP OF KEYMAPS #

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -108,12 +108,12 @@ define_conditional_modmap(lambda wm_class: wm_class.casefold() not in terminals,
 
     # - Default Mac/Win
     # - Default Win
-    Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
-    Key.LEFT_META: Key.LEFT_ALT,    # WinMac
-    Key.LEFT_CTRL: Key.LEFT_META,   # WinMac
-    Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
-    Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
-    Key.RIGHT_CTRL: Key.RIGHT_META, # WinMac - Multi-language (Remove)
+    # Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
+    # Key.LEFT_META: Key.LEFT_ALT,    # WinMac
+    # Key.LEFT_CTRL: Key.LEFT_META,   # WinMac
+    # Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
+    # Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
+    # Key.RIGHT_CTRL: Key.RIGHT_META, # WinMac - Multi-language (Remove)
 
     # - Mac Only
     # Key.LEFT_META: Key.RIGHT_CTRL,  # Mac
@@ -145,12 +145,12 @@ define_conditional_modmap(re.compile(termStr, re.IGNORECASE), {
 
     # - Default Mac/Win
     # - Default Win
-    Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
-    Key.LEFT_META: Key.LEFT_ALT,    # WinMac
-    Key.LEFT_CTRL: Key.LEFT_CTRL,   # WinMac
-    Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
-    Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
-    Key.RIGHT_CTRL: Key.LEFT_CTRL,  # WinMac - Multi-language (Remove)
+    # Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
+    # Key.LEFT_META: Key.LEFT_ALT,    # WinMac
+    # Key.LEFT_CTRL: Key.LEFT_CTRL,   # WinMac
+    # Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
+    # Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
+    # Key.RIGHT_CTRL: Key.LEFT_CTRL,  # WinMac - Multi-language (Remove)
 
     # - Mac Only
     # Key.LEFT_META: Key.RIGHT_CTRL,  # Mac

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -256,7 +256,7 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
 })
 
-# Keybindings overrides for elementary OS Files 
+# Keybindings overrides for Pantheon Files (elementary OS)
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
     K("RC-Shift-T"): K("Shift-Enter"),          # Open folder in new tab

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -221,7 +221,7 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 define_keymap(re.compile("caja", re.IGNORECASE),{
     # K("RC-Super-o"): K("RC-Shift-Enter"),   # Open in new tab 
     K("RC-Super-o"): K("RC-Shift-W"),       # Open in new window
-},"Overrides_Caja")
+},"Overrides for Caja - Finder")
 
 # Keybindings overrides for Dolphin 
 # (overrides some bindings from general file browser code block below)
@@ -235,14 +235,14 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     ### 
     K("RC-Shift-N"): K("F10"),                  # Create new folder
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
-},"Overrides_Dolphin")
+},"Overrides for Dolphin - Finder")
 
 # Keybindings overrides for elementary OS Files 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
     # K("RC-Super-o"): K("Shift-Enter"),          # Open folder in new tab
     K("RC-Comma"): None,                        # Disable preferences shortcut since none availabe
-},"Overrides_Pantheon")
+},"Overrides for Pantheon - Finder")
 
 # Keybindings overrides for Nautilus 
 # (overrides some bindings from general file browser code block below)
@@ -250,13 +250,13 @@ define_keymap(re.compile("org.gnome.Nautilus", re.IGNORECASE),{
     K("RC-Super-o"): K("Shift-Enter"),           # Open in new window
     # K("RC-Super-o"): K("RC-Enter"),                 # Open in new tab
     K("RC-comma"): K("RC-comma"),                   # Overrides "Open preferences dialog" shortcut below
-},"Overrides_Nautilus")
+},"Overrides for Nautilus - Finder")
 
 # Keybindings overrides for PCManFM 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("pcmanfm", re.IGNORECASE),{
     K("RC-Backspace"): [K("Delete"),K("Enter")],    # Move to Trash (delete, bypass dialog)
-},"Overrides_PCManFM")
+},"Overrides for PCManFM - Finder")
 
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file browser code block below)
@@ -266,14 +266,14 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
     K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
     # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences. 
     # SpaceFM seems to be doing some nasty binding that blocks things like Alt+Tab while the menu is open. 
-},"Overrides_SpaceFM")
+},"Overrides for SpaceFM - Finder")
 
 # Keybindings overrides for Thunar 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
     K("RC-Super-o"): K("RC-Shift-P"),          # Open in new tab
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
-},"Overrides_Thunar")
+},"Overrides for Thunar - Finder")
 
 filemanagers = [
     "caja",
@@ -319,7 +319,7 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
     K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
     K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)
-},"File_Managers")
+},"File Managers - Finder")
 
 ########################################
 # END OF FILE MANAGER GROUP OF KEYMAPS #

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -226,12 +226,12 @@ define_keymap(re.compile("caja", re.IGNORECASE),{
 # Keybindings overrides for Dolphin 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("dolphin", re.IGNORECASE),{
-    K("RC-Super-o"): K("RC-Shift-Enter"), # Open in new window 
-    # "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+Enter 
-    # in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.)
+    K("RC-Super-o"): K("RC-Shift-o"), # Open in new window (or new tab, user's choice)
+    # "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+o 
+    # in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.
     ### 
-    # "Open in new tab" requires manually setting custom shortcut of Ctrl+Shift+T in 
-    # Dolphin's keyboard shortcuts. This conflicts with and replaces "Undo close tab".
+    # "Open in new tab" requires manually setting custom shortcut of Ctrl+Shift+o in 
+    # Dolphin's keyboard shortcuts. There is no default shortcut set for this function. 
     ### 
     K("RC-Shift-N"): K("F10"),                  # Create new folder
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -343,7 +343,8 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
 
 # Open preferences in browsers
 define_keymap(re.compile("Firefox", re.IGNORECASE),{
-    K("C-comma"): [K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")],)
+    K("C-comma"): [K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")],
+})
 define_keymap(re.compile(chromeStr, re.IGNORECASE),{
     K("C-comma"): [K("M-e"), K("s"),K("Enter")],
 })

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -304,7 +304,7 @@ filemanagers = [
     "pcmanfm-qt",
     "spacefm",
     "thunar",
-    ]
+]
 filemanagers = [filemanager.casefold() for filemanager in filemanagers]
 filemanagerStr = "|".join(str(x) for x in filemanagers)
 

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -36,7 +36,10 @@ codeStr = "|".join(str(x) for x in mscodes)
 # Add remote desktop clients & VM software here
 # Ideally we'd only exclude the client window,
 # but that may not be easily done.
-remotes = ["org.remmina.Remmina","xfreerdp"]
+remotes = [
+    "org.remmina.Remmina",
+    "xfreerdp",
+]
 remotes = [client.casefold() for client in remotes]
 
 # Add remote desktop clients & VMs for no remapping
@@ -44,11 +47,26 @@ terminals.extend(remotes)
 mscodes.extend(remotes)
 
 # Use for browser specific hotkeys
-browsers = ["Chromium","Chromium-browser","Google-chrome","microsoft-edge-dev","microsoft-edge","Epiphany","Firefox","Discord"]
+browsers = [
+    "Chromium",
+    "Chromium-browser",
+    "Discord",
+    "Epiphany",
+    "Firefox",
+    "Google-chrome",
+    "microsoft-edge",
+    "microsoft-edge-dev",
+]
 browsers = [browser.casefold() for browser in browsers]
 browserStr = "|".join(str(x) for x in browsers)
 
-chromes = ["Chromium","Chromium-browser","Google-chrome","microsoft-edge-dev","microsoft-edge"]
+chromes = [
+    "Chromium",
+    "Chromium-browser",
+    "Google-chrome",
+    "microsoft-edge",
+    "microsoft-edge-dev",
+]
 chromes = [chrome.casefold() for chrome in chromes]
 chromeStr = "|".join(str(x) for x in chromes)
 
@@ -90,12 +108,12 @@ define_conditional_modmap(lambda wm_class: wm_class.casefold() not in terminals,
 
     # - Default Mac/Win
     # - Default Win
-    # Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
-    # Key.LEFT_META: Key.LEFT_ALT,    # WinMac
-    # Key.LEFT_CTRL: Key.LEFT_META,   # WinMac
-    # Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
-    # Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
-    # Key.RIGHT_CTRL: Key.RIGHT_META, # WinMac - Multi-language (Remove)
+    Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
+    Key.LEFT_META: Key.LEFT_ALT,    # WinMac
+    Key.LEFT_CTRL: Key.LEFT_META,   # WinMac
+    Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
+    Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
+    Key.RIGHT_CTRL: Key.RIGHT_META, # WinMac - Multi-language (Remove)
 
     # - Mac Only
     # Key.LEFT_META: Key.RIGHT_CTRL,  # Mac
@@ -127,12 +145,12 @@ define_conditional_modmap(re.compile(termStr, re.IGNORECASE), {
 
     # - Default Mac/Win
     # - Default Win
-    # Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
-    # Key.LEFT_META: Key.LEFT_ALT,    # WinMac
-    # Key.LEFT_CTRL: Key.LEFT_CTRL,   # WinMac
-    # Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
-    # Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
-    # Key.RIGHT_CTRL: Key.LEFT_CTRL,  # WinMac - Multi-language (Remove)
+    Key.LEFT_ALT: Key.RIGHT_CTRL,   # WinMac
+    Key.LEFT_META: Key.LEFT_ALT,    # WinMac
+    Key.LEFT_CTRL: Key.LEFT_CTRL,   # WinMac
+    Key.RIGHT_ALT: Key.RIGHT_CTRL,  # WinMac - Multi-language (Remove)
+    Key.RIGHT_META: Key.RIGHT_ALT,  # WinMac - Multi-language (Remove)
+    Key.RIGHT_CTRL: Key.LEFT_CTRL,  # WinMac - Multi-language (Remove)
 
     # - Mac Only
     # Key.LEFT_META: Key.RIGHT_CTRL,  # Mac
@@ -238,14 +256,14 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 # Keybindings overrides for Caja 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("caja", re.IGNORECASE),{
-    K("RC-Shift-T"): K("RC-Shift-Enter"),   # Open folder in new tab 
-    K("RC-Shift-o"): K("RC-Shift-W"),       # Open folder in new window
+    # K("RC-Super-o"): K("RC-Shift-Enter"),   # Open in new tab 
+    K("RC-Super-o"): K("RC-Shift-W"),       # Open in new window
 })
 
 # Keybindings overrides for Dolphin 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("dolphin", re.IGNORECASE),{
-    K("RC-Shift-o"): K("RC-Shift-Enter"), # Open folder in new window 
+    K("RC-Super-o"): K("RC-Shift-Enter"), # Open in new window 
     # "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+Enter 
     # in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.)
     ### 
@@ -256,18 +274,18 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
 })
 
-# Keybindings overrides for Pantheon Files (elementary OS)
+# Keybindings overrides for elementary OS Files 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
-    K("RC-Shift-T"): K("Shift-Enter"),          # Open folder in new tab
+    # K("RC-Super-o"): K("Shift-Enter"),          # Open folder in new tab
     K("RC-Comma"): None,                        # Disable preferences shortcut since none availabe
 })
 
 # Keybindings overrides for Nautilus 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("org.gnome.Nautilus", re.IGNORECASE),{
-    K("RC-Shift-o"): K("Shift-Enter"),           # Open in new window
-    K("RC-Shift-T"): K("RC-Enter"),                 # Open in new tab
+    K("RC-Super-o"): K("Shift-Enter"),           # Open in new window
+    # K("RC-Super-o"): K("RC-Enter"),                 # Open in new tab
     K("RC-comma"): K("RC-comma"),                   # Overrides "Open preferences dialog" shortcut below
 })
 
@@ -290,7 +308,7 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
 # Keybindings overrides for Thunar 
 # (overrides some bindings from general file browser code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
-    K("RC-Shift-T"): K("RC-Shift-P"),          # Open in new tab
+    K("RC-Super-o"): K("RC-Shift-P"),          # Open in new tab
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
 })
 
@@ -314,7 +332,7 @@ filemanagerStr = "|".join(str(x) for x in filemanagers)
 # Dolphin (KDE file manager)
 # Nautilus (GNOME file manager, may be called "Files")
 # Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
-# Pantheon Files (eOS file manager, fork of Nautilus)
+# Pantheon Files (elementary OS file manager, may be called "Files")
 # PCManFM (LXDE file manager)
 # PCManFM-Qt (LXQt file manager)
 # SpaceFM (Fork of PCManFM file manager)
@@ -328,9 +346,11 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     # K("RC-Down"): K("RC-O"),              # Go Down dir (open folder/file)
     K("RC-Down"): K("Enter"),               # Go Down dir (open folder/file)
     # K("RC-Shift-Down"): K("RC-Shift-o"),  # Open in new window (doesn't match Finder)
-    K("RC-Shift-o"): K("RC-Shift-o"),       # Open in new window
+    K("RC-Super-o"): K("RC-Shift-o"),       # Open in new window
     K("RC-Left"): K("M-Left"),              # Go Back
     K("RC-Right"): K("M-Right"),            # Go Forward
+    # To enable renaming files with the Enter key, uncomment the two lines just below. 
+    # Use Ctrl+Shift+Enter to escape or activate text fields. 
     # K("Enter"): K("F2"),				    # Rename with Enter key
     # K("RC-Shift-Enter"): K("Enter"),	    # Remap alternative "Enter" key to easily activate/exit text fields
     K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
@@ -360,17 +380,26 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
 
 # Open preferences in browsers
 define_keymap(re.compile("Firefox", re.IGNORECASE),{
-    K("C-comma"): [K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")],
+    K("C-comma"): [
+        K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),
+        K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),
+        K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")
+    ],
 })
 define_keymap(re.compile(chromeStr, re.IGNORECASE),{
     K("C-comma"): [K("M-e"), K("s"),K("Enter")],
 })
 # Opera C-F12
 
+define_keymap(re.compile(termStr, re.IGNORECASE),{
+    K("RC-Dot"): K("LC-C"),                         # Map Ctrl+Dot to Ctrl+C in terminals
+}, "Mapping Ctrl+Dot to Ctrl+C in terminals")
+
 # None referenced here originally
 # - but remote clients and VM software ought to be set here
 # These are the typical remaps for ALL GUI based apps
 define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
+    K("RC-Dot"): K("Esc"),                          # Mimic macOS Cmd+dot = Escape key (not in terminals)
     K("RC-Space"): K("Alt-F1"),                   # Default SL - Launch Application Menu (gnome/kde)
     K("RC-F3"):K("Super-d"),                      # Default SL - Show Desktop (gnome/kde,eos)
     K("RC-Super-f"):K("M-F10"),                      # Default SL - Maximize app (gnome/kde)
@@ -437,13 +466,11 @@ define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
     K("RC-Shift-Up"): K("C-Shift-Home"),          # Select all to Beginning of File
     K("RC-Down"): K("C-End"),                     # End of File
     K("RC-Shift-Down"): K("C-Shift-End"),         # Select all to End of File
-    # K("RM-Backspace"): K("Delete"),               # Chromebook/IBM - Delete
-    K("Super-Backspace"): K("C-Backspace"),       # Delete Left Word of Cursor
-    K("Super-Delete"): K("C-Delete"),             # Delete Right Word of Cursor
-    # K("LM-Backspace"): K("C-Backspace"),          # Chromebook/IBM - Delete Left Word of Cursor
-    K("M-Backspace"): K("C-Backspace"),           # Default not-chromebook
-    K("RC-Backspace"): K("C-Shift-Backspace"),    # Delete Entire Line Left of Cursor
-    K("Alt-Delete"): K("C-Delete"),               # Delete Right Word of Cursor
+    # K("M-Backspace"): K("Delete"),                # Chromebook/IBM - Delete
+    K("Super-Backspace"): K("C-Backspace"),       # Default not-chromebook - Delete Left Word of Cursor
+    K("Super-Delete"): K("C-Delete"),             # Default not-chromebook - Delete Right Word of Cursor
+    K("Alt-Backspace"): K("C-Backspace"),         # Default not-chromebook - Delete Left Word of Cursor
+    K("Alt-Delete"): K("C-Delete"),               # Default not-chromebook - Delete Right Word of Cursor
     # K(""): pass_through_key,                      # cancel
     # K(""): K(""),                                 #
 })
@@ -654,7 +681,7 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     K("RC-N"): K("C-Shift-N"),
     K("RC-M"): K("C-Shift-M"),
     K("RC-COMMA"): K("C-Shift-COMMA"),
-    K("RC-DOT"): K("C-Shift-DOT"),
+    # K("RC-DOT"): K("C-Shift-DOT"),
     K("RC-SLASH"): K("C-Shift-SLASH"),
     K("RC-KPASTERISK"): K("C-Shift-KPASTERISK"),
 }, "terminals")


### PR DESCRIPTION
Code to add Finder-like keyboard shortcut support to common Linux file managers: 

Caja File Browser (MATE file manager, fork of Nautilus)
Dolphin (KDE file manager)
Nautilus (GNOME file manager, may be called "Files")
Nemo (Cinnamon file manager, fork of Nautilus, may be called "Files")
PCManFM (LXDE/LXQt file manager)
SpaceFM (Fork of PCManFM file manager)
Thunar File Manager (Xfce file manager)

Usage of "Enter" key to rename (F2) like the Finder works, technically, but it is disabled here, until support for modifying the Enter key behavior inside text fields can be added. 
Anyone who wants to use it will have to enable it manually, along with the shortcut to help escape/activate text fields.