### PR TITLE
Fix for installing Kinto on Ubuntu 20.04.x and 20.10.x

### DIFF
--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -578,11 +578,11 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 	if [ "$distro" == "linuxmint" ] && [ "$dename" == "cinnamon" ]; then
 		echo
 		echo "======================================================================================"
-		echo "ATTENTION! SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT: "
+		echo "======== ATTENTION! SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT: ========="
 		echo "======================================================================================"
 		echo 
 		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working correctly in "
-		echo "Mint Cinnamon after activating Kinto via the GUI: "
+		echo "Mint Cinnamon after activating Kinto via the GUI installer window: "
 		echo 
 		echo "Open the Keyboard settings app from the Cinnamon main menu. Go to the Shortcuts tab. "
 		echo 
@@ -597,8 +597,11 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 		echo 
 		echo "Use physical Ctrl+H keys to assign the shortcut \"Super+H\". Now Alt+H (or Cmd+H) will minimize (hide). "
 		echo 
+		echo "Kinto may have crashed if you Alt+Tabbed in the GUI window before fixing the shortcuts. "
+		echo "Just use the tray icon menu or quit and re-open the Kinto GUI and restart Kinto from menu. "
+		echo 
 		echo "======================================================================================"
-		echo "END OF SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT (See above) "
+		echo "===== END OF SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT (See above) ====="
 		echo "======================================================================================"
 		echo 
 	fi

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -575,7 +575,7 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 	echo -e "~/.config/kinto/gui/kinto-gui.py\n"
 	echo -e "You can then either \e]8;;https://google.com\a\e[1m\e[36mG\033[0;91mo\033[0;93mo\e[1m\e[36mg\e[1m\e[32ml\033[0;91me\e[0m\e]8;;\a what dependencies you may be missing\nor \e]8;;https://github.com/rbreaves/kinto/issues/new\?assignees=rbreaves&labels=bug&template=bug_report.md&title=\aopen an issue ticket.\e]8;;\a\n"
 
-	if [ "$distro" == "linuxmint" && [ "$dename" == "cinnamon" ]; then
+	if [ "$distro" == "linuxmint" ] && [ "$dename" == "cinnamon" ]; then
 		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working in Mint Cinnamon: "
 		echo "Open the Keyboard settings app from Cinnamon main menu. Go to the Shortcuts tab. "
 		echo "Under General -> Cycle through open windows: "

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -344,9 +344,7 @@ if [ "$distro" == "ubuntu" ]; then
 	sudo ./linux/system-config/unipkg.sh git
 fi
 if ! [ -x "$(command -v python3-config)" ]; then
-	if [ "$distro" == "ubuntu" ]; then
-		sudo ./linux/system-config/unipkg.sh python3-dev
-	elif [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
+	if [ "$distro" == "ubuntu" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		pydev="python3-dev"
 	elif [ "$distro" == "fedora" ]; then
 		pydev="python3-devel"

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -586,14 +586,15 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 		echo 
 		echo "Open the Keyboard settings app from the Cinnamon main menu. Go to the Shortcuts tab. "
 		echo 
-		echo "Under General -> Cycle through open windows: "
+		echo "Under General -> \"Cycle through open windows\": "
 		echo "Click \"unassigned\" under the existing \"Alt+Tab\" shortcut until it says \"Pick an accelerator\"."
 		echo 
-		echo "Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut showing as \"Ctrl+Backslash\". "
+		echo "Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut (will show as \"Ctrl+Backslash\". "
 		echo 
 		echo "Optional: "
-		echo "Set \"Cycle backwards through open windows\" to use Alt+Shift+Tab (will display as Shift+Ctrl+\|). "
-		echo "Under Windows -> Minimize window: "
+		echo "Set \"Cycle backwards through open windows\" to use physical Shift+Alt+Tab (will show as \"Shift+Ctrl+\|\"). "
+		echo 
+		echo "Under Windows -> \"Minimize window\": "
 		echo 
 		echo "Use physical Ctrl+H keys to assign the shortcut \"Super+H\". Now Alt+H (or Cmd+H) will minimize (hide). "
 		echo 

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -209,6 +209,19 @@ sudo systemctl disable xkeysnail >/dev/null 2>&1
 sudo pkill -f bin/xkeysnail >/dev/null 2>&1
 sudo pkill -f "is-active xkeysnail" >/dev/null 2>&1
 
+if ! [ -x "$(command -v pip3)" ]; then
+	if [ "$distro" == "ubuntu" ]; then
+		echo "Will need to install pip..."
+		sudo ./linux/system-config/unipkg.sh curl
+		curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+		sudo python3 get-pip.py --upgrade
+		rm get-pip.py
+	fi
+else
+	echo "Will need to install python3-pip..."
+	sudo ./linux/system-config/unipkg.sh python3-pip
+fi
+
 pip3 install pillow
 
 # Add additional shortcuts if needed, does not modify existing ones
@@ -326,12 +339,14 @@ expsh=" "
 # 	echo "Will need to install inotify-tools to restart key remapper live for config file changes..."
 # 	sudo ./linux/system-config/unipkg.sh inotify-tools
 # fi
-if ! [ -x "$(command -v pip3)" ]; then
-	echo "Will need to install python3-pip..."
-	sudo ./linux/system-config/unipkg.sh python3-pip
+if [ "$distro" == "ubuntu" ]; then
+	sudo ./linux/system-config/unipkg.sh gcc
 fi
 if ! [ -x "$(command -v python3-config)" ]; then
-	if [ "$distro" == "ubuntu" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
+	if [ "$distro" == "ubuntu" ]; then
+		sudo ./linux/system-config/unipkg.sh python3-dev
+		sudo ./linux/system-config/unipkg.sh python3-setuptools
+	elif [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		pydev="python3-dev"
 	elif [ "$distro" == "fedora" ]; then
 		pydev="python3-devel"

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -347,8 +347,11 @@ if [ "$desktopsession" == "Lubuntu" ] || [ "$currentdesktop" == "LXQt" ]; then
 	sudo ./linux/system-config/unipkg.sh gir1.2-vte-2.91
 fi
 
-if [ "$distro" == "ubuntu" ] || [ "$distro" == "kdeneon" ]; then
+if ! [ -x "$(command -v gcc)" ]; then
 	sudo ./linux/system-config/unipkg.sh gcc
+fi
+
+if ! [ -x "$(command -v git)" ]; then
 	sudo ./linux/system-config/unipkg.sh git
 fi
 

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -479,6 +479,13 @@ if [[ $dename == "xfce" ]]; then
 	perl -pi -e "s/(\w.*)(# Default not-xfce4)/# \$1\$2/g" ./linux/kinto.py.new
 fi
 
+# Use xfce4 tweaks also on Linux Mint Cinnamon
+if [[ $dename == "cinnamon" ]] && [[ $distro == "linuxmint" ]]; then
+	perl -pi -e "\s{4}(# )(K.*)(# SL - .*xfce.*)/    \$2\$3/g" ./linux/kinto.py.new >/dev/null 2>&1
+	perl -pi -e "s/(# )(.*)(# xfce4)/\$2\$3/g" ./linux/kinto.py.new
+	perl -pi -e "s/(\w.*)(# Default not-xfce4)/# \$1\$2/g" ./linux/kinto.py.new
+fi
+
 if [[ $dename == "xfce" ]] && ls /etc/apt/sources.list.d/enso* 1> /dev/null 2>&1; then
     echo "enso OS detected, applying Cmd-Space for Launchy..."
     perl -pi -e "s/(K\(\"RC-Space)(.*)(# )(xfce4)/\$3\$1\$2\$3\$4/g" ./linux/kinto.py.new >/dev/null 2>&1

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -588,15 +588,14 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 		echo 
 		echo "Under General -> \"Cycle through open windows\": "
 		echo "Click \"unassigned\" under the existing \"Alt+Tab\" shortcut until it says \"Pick an accelerator\"."
-		echo 
 		echo "Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut (will show as \"Ctrl+Backslash\". "
 		echo 
-		echo "Optional: "
-		echo "Set \"Cycle backwards through open windows\" to use physical Shift+Alt+Tab (will show as \"Shift+Ctrl+\|\"). "
+		echo "Optional: Set \"Cycle backwards through open windows\":"
+		echo "Press physical Shift+Alt+Tab (will show as \"Shift+Ctrl+|\"). [Vertical bar/pipe character] "
 		echo 
 		echo "Under Windows -> \"Minimize window\": "
-		echo 
-		echo "Use physical Ctrl+H keys to assign the shortcut \"Super+H\". Now Alt+H (or Cmd+H) will minimize (hide). "
+		echo "Press physical Ctrl+H keys to assign the shortcut to show as \"Super+H\". "
+		echo "Now physical Alt+H (or Cmd+H on Apple keyboard) will minimize (hide) windows. "
 		echo 
 		echo "Kinto may have crashed if you Alt+Tabbed in the GUI window before fixing the shortcuts. "
 		echo "Just use the tray icon menu or quit and re-open the Kinto GUI and restart Kinto from menu. "

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -348,7 +348,7 @@ if [ "$desktopsession" == "Lubuntu" ] || [ "$currentdesktop" == "LXQt" ]; then
 fi
 
 if [ "$distro" == "opensusetumbleweed" ]; then
-	sudo ./linux/system-config/unipkg.sh typelib-1_0-Vte-2.91necessary
+	sudo ./linux/system-config/unipkg.sh typelib-1_0-Vte-2.91
 fi
 
 if ! [ -x "$(command -v gcc)" ]; then

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -575,6 +575,19 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 	echo -e "~/.config/kinto/gui/kinto-gui.py\n"
 	echo -e "You can then either \e]8;;https://google.com\a\e[1m\e[36mG\033[0;91mo\033[0;93mo\e[1m\e[36mg\e[1m\e[32ml\033[0;91me\e[0m\e]8;;\a what dependencies you may be missing\nor \e]8;;https://github.com/rbreaves/kinto/issues/new\?assignees=rbreaves&labels=bug&template=bug_report.md&title=\aopen an issue ticket.\e]8;;\a\n"
 
+	if [ "$distro" == "linuxmint" && [ "$dename" == "cinnamon" ]; then
+		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working in Mint Cinnamon: "
+		echo "Open the Keyboard settings app from Cinnamon main menu. Go to the Shortcuts tab. "
+		echo "Under General -> Cycle through open windows: "
+		echo "Click \"unassigned\" under \"Alt+Tab\" shortcut. "
+		echo "Press physical Alt+Tab keys to add a second shortcut showing as \"Ctrl+Backslash\". "
+		echo "Optional: "
+		echo "Set \"Cycle backwards through open windows\" to use Alt+Shift+Tab (will display as Shift+Ctrl+\|). "
+		echo "Under Windows -> Minimize window: "
+		echo "Use physical Ctrl+H keys to assign the shortcut as Super+H. Now Alt+H (Cmd+H on Macs) will work. "
+		echo 
+	fi
+	
 	if [ "$distro" == "manjarolinux" ]; then
 		echo "If you are using Manjaro and see an error about 'GLIBC_2.xx not found' appears then please update your system."
 		echo "sudo pacman -Syu"

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -362,7 +362,7 @@ fi
 if ! [ -x "$(command -v python3-config)" ]; then
 	if [ "$distro" == "ubuntu" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		pydev="python3-dev"
-	elif [ "$distro" == "fedora" ]; then
+	elif [ "$distro" == "fedora" ] || [ "$distro" == "opensusetumbleweed" ]; then
 		pydev="python3-devel"
 	fi
 	if [ "$distro" == "ubuntu" ] || [ "$distro" == "gnome" ] || [ "$distro" == "fedora" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -341,6 +341,7 @@ expsh=" "
 # fi
 if [ "$distro" == "ubuntu" ]; then
 	sudo ./linux/system-config/unipkg.sh gcc
+	sudo ./linux/system-config/unipkg.sh git
 fi
 if ! [ -x "$(command -v python3-config)" ]; then
 	if [ "$distro" == "ubuntu" ]; then

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -216,10 +216,10 @@ if ! [ -x "$(command -v pip3)" ]; then
 		sudo ./linux/system-config/unipkg.sh python3-setuptools
 		curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 		sudo python3 get-pip.py --upgrade && rm get-pip.py
+	else
+		echo "Will need to install python3-pip..."
+		sudo ./linux/system-config/unipkg.sh python3-pip
 	fi
-else
-	echo "Will need to install python3-pip..."
-	sudo ./linux/system-config/unipkg.sh python3-pip
 fi
 
 pip3 install pillow
@@ -347,10 +347,11 @@ if [ "$desktopsession" == "Lubuntu" ] || [ "$currentdesktop" == "LXQt" ]; then
 	sudo ./linux/system-config/unipkg.sh gir1.2-vte-2.91
 fi
 
-if [ "$distro" == "ubuntu" ]; then
+if [ "$distro" == "ubuntu" ] || [ "$distro" == "kdeneon" ]; then
 	sudo ./linux/system-config/unipkg.sh gcc
 	sudo ./linux/system-config/unipkg.sh git
 fi
+
 if ! [ -x "$(command -v python3-config)" ]; then
 	if [ "$distro" == "ubuntu" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		pydev="python3-dev"
@@ -362,6 +363,7 @@ if ! [ -x "$(command -v python3-config)" ]; then
 		sudo ./linux/system-config/unipkg.sh "$pydev"
 	fi
 fi
+
 # if [ "$distro" == "ubuntu" ] && [ "$dename" == "gnome" ];then
 # 	sudo ./linux/system-config/unipkg.sh gnome-tweaks gnome-shell-extension-appindicator gir1.2-appindicator3-0.1
 # fi
@@ -370,6 +372,7 @@ if ! [ -x "$(command -v xhost)" ] || ! [ -x "$(command -v gcc)" ]; then
 		sudo ./linux/system-config/unipkg.sh "xorg-xhost gcc"
 	fi
 fi
+
 if [ "$distro" == 'linuxmint' ]; then
 	pip3 install setuptools
 fi

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -349,7 +349,7 @@ if ! [ -x "$(command -v python3-config)" ]; then
 	elif [ "$distro" == "fedora" ]; then
 		pydev="python3-devel"
 	fi
-	if [ "$distro" == "gnome" ] || [ "$distro" == "fedora" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
+	if [ "$distro" == "ubuntu" ] || [ "$distro" == "gnome" ] || [ "$distro" == "fedora" ] || [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		echo "Will need to install $pydev..."
 		sudo ./linux/system-config/unipkg.sh "$pydev"
 	fi

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -214,8 +214,7 @@ if ! [ -x "$(command -v pip3)" ]; then
 		echo "Will need to install pip..."
 		sudo ./linux/system-config/unipkg.sh curl
 		curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-		sudo python3 get-pip.py --upgrade
-		rm get-pip.py
+		sudo python3 get-pip.py --upgrade && rm get-pip.py
 	fi
 else
 	echo "Will need to install python3-pip..."

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -581,21 +581,21 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 		echo "======== ATTENTION! SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT: ========="
 		echo "======================================================================================"
 		echo 
-		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working correctly in "
+		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize/hide window) working correctly in "
 		echo "Mint Cinnamon after activating Kinto via the GUI installer window: "
 		echo 
 		echo "Open the Keyboard settings app from the Cinnamon main menu. Go to the Shortcuts tab. "
 		echo 
 		echo "Under General -> \"Cycle through open windows\": "
-		echo "Click \"unassigned\" under the existing \"Alt+Tab\" shortcut until it says \"Pick an accelerator\"."
-		echo "Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut (will show as \"Ctrl+Backslash\". "
+		echo "  Click \"unassigned\" under the existing \"Alt+Tab\" shortcut until it says \"Pick an accelerator\"."
+		echo "  Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut (will show as \"Ctrl+Backslash\". "
 		echo 
 		echo "Optional: Set \"Cycle backwards through open windows\":"
-		echo "Press physical Shift+Alt+Tab (will show as \"Shift+Ctrl+|\"). [Vertical bar/pipe character] "
+		echo "  Press physical Shift+Alt+Tab (will show as \"Shift+Ctrl+|\"). [Vertical bar/pipe character] "
 		echo 
 		echo "Under Windows -> \"Minimize window\": "
-		echo "Press physical Ctrl+H keys to assign the shortcut to show as \"Super+H\". "
-		echo "Now physical Alt+H (or Cmd+H on Apple keyboard) will minimize (hide) windows. "
+		echo "  Press physical Ctrl+H keys to assign the shortcut to show as \"Super+H\". "
+		echo "  Now physical Alt+H (or Cmd+H on Apple keyboard) will minimize (hide) windows. "
 		echo 
 		echo "Kinto may have crashed if you Alt+Tabbed in the GUI window before fixing the shortcuts. "
 		echo "Just use the tray icon menu or quit and re-open the Kinto GUI and restart Kinto from menu. "

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -341,9 +341,9 @@ expsh=" "
 # fi
 
 desktopsession=$(echo $DESKTOP_SESSION)
-currentdesktop=$(env | grep XDG_CURRENT_DESKTOP)
+currentdesktop=$(env | grep -i XDG_CURRENT_DESKTOP | awk -F"=" '/=/{print $2}')
 
-if [ "$desktopsession" == "Lubuntu" ]; then
+if [ "$desktopsession" == "Lubuntu" ] || [ "$currentdesktop" == "LXQt" ]; then
 	sudo ./linux/system-config/unipkg.sh gir1.2-vte-2.91
 fi
 

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -339,6 +339,14 @@ expsh=" "
 # 	echo "Will need to install inotify-tools to restart key remapper live for config file changes..."
 # 	sudo ./linux/system-config/unipkg.sh inotify-tools
 # fi
+
+desktopsession=$(echo $DESKTOP_SESSION)
+currentdesktop=$(env | grep XDG_CURRENT_DESKTOP)
+
+if [ "$desktopsession" == "Lubuntu" ]; then
+	sudo ./linux/system-config/unipkg.sh gir1.2-vte-2.91
+fi
+
 if [ "$distro" == "ubuntu" ]; then
 	sudo ./linux/system-config/unipkg.sh gcc
 	sudo ./linux/system-config/unipkg.sh git

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -213,6 +213,7 @@ if ! [ -x "$(command -v pip3)" ]; then
 	if [ "$distro" == "ubuntu" ]; then
 		echo "Will need to install pip..."
 		sudo ./linux/system-config/unipkg.sh curl
+		sudo ./linux/system-config/unipkg.sh python3-setuptools
 		curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 		sudo python3 get-pip.py --upgrade && rm get-pip.py
 	fi

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -576,15 +576,30 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 	echo -e "You can then either \e]8;;https://google.com\a\e[1m\e[36mG\033[0;91mo\033[0;93mo\e[1m\e[36mg\e[1m\e[32ml\033[0;91me\e[0m\e]8;;\a what dependencies you may be missing\nor \e]8;;https://github.com/rbreaves/kinto/issues/new\?assignees=rbreaves&labels=bug&template=bug_report.md&title=\aopen an issue ticket.\e]8;;\a\n"
 
 	if [ "$distro" == "linuxmint" ] && [ "$dename" == "cinnamon" ]; then
-		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working in Mint Cinnamon: "
-		echo "Open the Keyboard settings app from Cinnamon main menu. Go to the Shortcuts tab. "
+		echo
+		echo "======================================================================================"
+		echo "ATTENTION! SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT: "
+		echo "======================================================================================"
+		echo 
+		echo "To get Alt+Tab (cycle windows) and Ctrl+H (minimize window) working correctly in "
+		echo "Mint Cinnamon after activating Kinto via the GUI: "
+		echo 
+		echo "Open the Keyboard settings app from the Cinnamon main menu. Go to the Shortcuts tab. "
+		echo 
 		echo "Under General -> Cycle through open windows: "
-		echo "Click \"unassigned\" under \"Alt+Tab\" shortcut. "
-		echo "Press physical Alt+Tab keys to add a second shortcut showing as \"Ctrl+Backslash\". "
+		echo "Click \"unassigned\" under the existing \"Alt+Tab\" shortcut until it says \"Pick an accelerator\"."
+		echo 
+		echo "Press physical Alt+Tab (or Cmd+Tab) keys to add a second shortcut showing as \"Ctrl+Backslash\". "
+		echo 
 		echo "Optional: "
 		echo "Set \"Cycle backwards through open windows\" to use Alt+Shift+Tab (will display as Shift+Ctrl+\|). "
 		echo "Under Windows -> Minimize window: "
-		echo "Use physical Ctrl+H keys to assign the shortcut as Super+H. Now Alt+H (Cmd+H on Macs) will work. "
+		echo 
+		echo "Use physical Ctrl+H keys to assign the shortcut \"Super+H\". Now Alt+H (or Cmd+H) will minimize (hide). "
+		echo 
+		echo "======================================================================================"
+		echo "END OF SPECIAL INSTRUCTIONS FOR CINNAMON DESKTOP ON LINUX MINT (See above) "
+		echo "======================================================================================"
 		echo 
 	fi
 	

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -346,7 +346,6 @@ fi
 if ! [ -x "$(command -v python3-config)" ]; then
 	if [ "$distro" == "ubuntu" ]; then
 		sudo ./linux/system-config/unipkg.sh python3-dev
-		sudo ./linux/system-config/unipkg.sh python3-setuptools
 	elif [ "$distro" == "debian" ] || [ "$distro" == 'linuxmint' ]; then
 		pydev="python3-dev"
 	elif [ "$distro" == "fedora" ]; then

--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -347,6 +347,10 @@ if [ "$desktopsession" == "Lubuntu" ] || [ "$currentdesktop" == "LXQt" ]; then
 	sudo ./linux/system-config/unipkg.sh gir1.2-vte-2.91
 fi
 
+if [ "$distro" == "opensusetumbleweed" ]; then
+	sudo ./linux/system-config/unipkg.sh typelib-1_0-Vte-2.91necessary
+fi
+
 if ! [ -x "$(command -v gcc)" ]; then
 	sudo ./linux/system-config/unipkg.sh gcc
 fi


### PR DESCRIPTION
- Moved the installation of pip to just prior to the first attempted invocation of "pip3 install pillow" at line 212 in original file.
- If Ubuntu, trigger install of package "gcc", needed to complete Kinto setup. 
- Split "ubuntu" from "debian" and "linuxmint" to trigger install of additional package "python3-setuptools" after "python3-dev". Might also be necessary for Debian and Mint in the near future.