### PR TITLE
Update deprecated "--force-yes" option to remove error in setup output

### DIFF
--- a/linux/system-config/unipkg.sh
+++ b/linux/system-config/unipkg.sh
@@ -3,7 +3,7 @@
 if pkgmgr="$( which apt-get )" 2> /dev/null; then
    echo "Debian"
    $pkgmgr update
-   $pkgmgr --yes --force-yes install $1
+   $pkgmgr --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install $1
 elif pkgmgr="$( which dnf )" 2> /dev/null; then
    echo "dnf"
    $pkgmgr check-update; $pkgmgr install -y $1

--- a/linux/system-config/unipkg.sh
+++ b/linux/system-config/unipkg.sh
@@ -10,6 +10,10 @@ elif pkgmgr="$( which dnf )" 2> /dev/null; then
 elif pkgmgr="$( which pacman )" 2> /dev/null; then
    echo "Arch-based"
    $pkgmgr -Syy;yes | $pkgmgr -S $1
+elif pkgmgr="$( which zypper )" 2> /dev/null; then
+   echo "openSUSE"
+   $pkgmgr refresh
+   $pkgmgr -n install $1
 else
    echo "Package manager not found, please install $1" >&2
    exit 1


### PR DESCRIPTION
Updating the deprecated "--force-yes" option and replacing with recommended "--allow-downgrades --allow-remove-essential --allow-change-held-packages" to keep warning from appearing in Kinto setup output. 

Reference: 

https://github.com/jontewks/puppeteer-heroku-buildpack/pull/30/commits/82d8c6fbfc7646a66497c6e38fa0d9d02afd2b6f

Additional reference: 

From https://manpages.debian.org/unstable/apt/apt-get.8.en.html

```
--force-yes

Force yes; this is a dangerous option that will cause apt to continue 
without prompting if it is doing something potentially harmful. It 
should not be used except in very special situations. Using force-yes 
can potentially destroy your system! Configuration Item: 
APT::Get::force-yes. This is deprecated and replaced by --allow-
unauthenticated , --allow-downgrades , --allow-remove-essential , 
--allow-change-held-packages in 1.1.

```
