### PR TITLE
Ensure git is installed before trying to use it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,9 @@ if os.path.isdir(homedir + "/.config/kinto") == False:
 	os.mkdir(homedir + "/.config/kinto")
 	time.sleep(0.5)
 
+if ! [ -x "$(command -v git)" ]; then
+	sudo ./linux/system-config/unipkg.sh git	# Don't assume git is installed. User might be installing from ZIP file. 
+fi
 
 cmdline("git fetch")
 


### PR DESCRIPTION
Git is needed to show Kinto version at start of setup. Therefore, ensure that git is installed in the case that the user is installing from a manually downloaded ZIP file rather than a `git clone`. 

EDIT: Of course I mixed up shell code with python code. This won't work. I have to figure out how to do it in python. Duh. 