### PR TITLE
Add shortcuts for browser prev and next tab switching

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -234,6 +234,8 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_7"): K("M-Key_7"),
     K("RC-Key_8"): K("M-Key_8"),
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
+    K("C-Left_Brace"): K("C-Page_Up"),
+    K("C-Right_Brace"): K("C-Page_Down"),
 })
 
 # Open preferences in browsers


### PR DESCRIPTION
I use "cmd-[" and "cmd-]" frequently, and I'm probably not alone.