### PR TITLE
Remove duplicate line for mapping Ctrl+V in terminals

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -499,7 +499,6 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     # K("RC-Shift-Tab"): K("RC-Shift-backslash"),   # xfce4
     # K("RC-Grave"): K("RC-Shift-backslash"),       # xfce4
     # Converts Cmd to use Ctrl-Shift
-    K("RC-V"): K("C-Shift-V"),
     K("RC-MINUS"): K("C-Shift-MINUS"),
     K("RC-EQUAL"): K("C-Shift-EQUAL"),
     K("RC-BACKSPACE"): K("C-Shift-BACKSPACE"),


### PR DESCRIPTION
There is an identical line a few lines below where Z/X/C/V are all mapped together. 