### PR TITLE
Add zypper support, make unipkg.sh output easier to read

### DIFF
--- a/linux/system-config/unipkg.sh
+++ b/linux/system-config/unipkg.sh
@@ -1,15 +1,31 @@
 #!/bin/bash
 
 if pkgmgr="$( which apt-get )" 2> /dev/null; then
-   echo "Debian"
+   echo 
+   echo "Debian apt-get package manager detected... "
+   echo "Installing $1... "
+   echo 
    $pkgmgr update
-   $pkgmgr --yes --force-yes install $1
+   $pkgmgr --yes install $1
 elif pkgmgr="$( which dnf )" 2> /dev/null; then
-   echo "dnf"
+   echo 
+   echo "dnf package manager detected... "
+   echo "Installing $1... "
+   echo 
    $pkgmgr check-update; $pkgmgr install -y $1
 elif pkgmgr="$( which pacman )" 2> /dev/null; then
-   echo "Arch-based"
+   echo 
+   echo "Arch-based pacman package manager detected... "
+   echo "Installing $1... "
+   echo 
    $pkgmgr -Syy;yes | $pkgmgr -S $1
+elif pkgmgr="$( which zypper )" 2> /dev/null; then
+   echo 
+   echo "zypper package manager detected... "
+   echo "Installing $1... "
+   echo 
+   $pkgmgr refresh
+   $pkgmgr -n install $1
 else
    echo "Package manager not found, please install $1" >&2
    exit 1


### PR DESCRIPTION
Removing "--allow-downgrades --allow-remove-essential --allow-change-held-packages" as a replacement for "--force-yes" because none of those options are really recommended. They can potentially break the system entirely, and shouldn't actually be necessary in any normal situation when installing packages. 

This adds some strategic blank lines and "descriptions" of what is happening so things are far more clear in the terminal during install. Aids in troubleshooting which parts go wrong. 

Adds support for the zypper package manager used by openSUSE Tumbleweed.