### PR TITLE
Ask user to verify if Manjaro is updated

### DIFF
--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -209,6 +209,25 @@ sudo systemctl disable xkeysnail >/dev/null 2>&1
 sudo pkill -f bin/xkeysnail >/dev/null 2>&1
 sudo pkill -f "is-active xkeysnail" >/dev/null 2>&1
 
+if [ "$distro" == "manjarolinux" ]; then
+	while true; do
+		read -rep $'\nHave you run \"sudo pacman -Syu\" before running Kinto setup? (y/n): ' updated	
+		case $updated in
+			[Yy]* ) mjupdated='yes'; break;;
+			[Nn]* ) mjupdated='no'; break;;
+			* ) echo -e "\nPlease answer [y]es or [n]o.";;
+		esac
+	done
+	if [[ "$mjupdated" == "no" ]]; then 
+		echo 
+		echo "================================================================================"
+		echo "==========  Please run a full system update before installing Kinto.  ==========" 
+		echo "================================================================================"
+		echo 
+		exit 0
+	fi
+fi
+
 pip3 install pillow
 
 # Add additional shortcuts if needed, does not modify existing ones


### PR DESCRIPTION
Install will fail (GUI window will not appear) on Manjaro unless system is fully updated first. This patch asks users to verify that they've run "sudo pacman -Syu" before attempting install. 

Failure is possibly related to the GLIB error mentioned later in the install script. Not certain. But a full update always got Manjaro to finally show the GUI installer window.