### PR TITLE
Inline export DISPLAY on openSUSE Tumbleweed

### DIFF
--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -491,6 +491,12 @@ if ! [[ $1 == "5" || $1 == "uninstall" || $1 == "Uninstall" ]]; then
 	fi
 	sed -i "s#{xkeysnail}#`which xkeysnail`#g" ./linux/xkeysnail.service.new
 	sed -i "s#{xkeysnail}#`which xkeysnail`#g" ./linux/limitedadmins.new
+	
+	# openSUSE Tumbleweed needs DISPLAY exported inside main command to avoid display "" not found error. 
+	if [ "$distro" == "opensusetumbleweed" ]; then
+		sed -i "s#'/usr/bin/xhost#'export DISPLAY=`echo $DISPLAY` \&\& /usr/bin/xhost#g" ./linux/xkeysnail.service.new
+	fi
+	
 	sudo mv ./linux/xkeysnail.service.new "$xkeypath"xkeysnail.service && echo "Service file added to "$xkeypath"xkeysnail.service"
 	sudo chown root:root ./linux/limitedadmins.new
 	# Add a check here for xkeysnail path resolving


### PR DESCRIPTION
OpenSUSE Tumbleweed has an error where install completes but the xkeysnail service won't run due to "display not found". Double quotes together indicates display environment variable inside the command is nonexistent or empty. 

This patch inlines `export DISPLAY=` [ insert actual DISPLAY variable value] at the beginning of the main command in the xkeysnail service file, just before the file is copied into its destination. 

Don't know of any other way to fix the issue on Tumbleweed. Tried moving the "Environment" line before the "ExecStart" line in the service file, that of course made no difference.