### PR TITLE
ctrl+fn arrow-up/arrow-down on linux browsers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -400,6 +400,8 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
     K("C-Left_Brace"): K("C-Page_Up"),
     K("C-Right_Brace"): K("C-Page_Down"),
+    K("Super-Page_Up"): K("C-Page_Up"),
+    K("Super-Page_Down"): K("C-Page_Down"),
 })
 
 # Open preferences in browsers


### PR DESCRIPTION
Same behavior/layout as mac when the keyboard's page-up/down keys are triggered with fn+up/down (e.g. no standalone page-up/down keys).