### PR TITLE
Add GNOME Boxes WM_CLASS for Linux, and a comma

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -41,7 +41,8 @@ remotes = [
     "org.remmina.Remmina",
     "xfreerdp",
     "VirtualBox Machine",
-    "VirtualBox"
+    "VirtualBox",
+    "Gnome-boxes",
 ]
 remotes = [client.casefold() for client in remotes]
 


### PR DESCRIPTION
Note: I'm trying to consistently leave a comma after the last item in each vertically formatted python list, so that when someone with less python knowledge wants to add something to the list and does it the "lazy way" by just copying the last line, pasting it on the end and editing it to add a new item, they won't cause the "missing comma" python error too easily. Having a comma on the very end of the list with no element after it doesn't seem to cause any harm or python errors. And you can copy/paste the last item as many times as you want without getting into trouble.