### PR TITLE
Ctrl(Super)+PgUp/PgDn instead of braces for tab navigation in browsers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -402,8 +402,11 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_7"): K("M-Key_7"),
     K("RC-Key_8"): K("M-Key_8"),
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
-    K("C-Left_Brace"): K("C-Page_Up"),
-    K("C-Right_Brace"): K("C-Page_Down"),
+    K("Super-Page_Up"):     K("C-Page_Up"),     # Go to prior tab
+    K("Super-Page_Down"):   K("C-Page_Down"),   # Go to next tab
+    # Use brace keys for tab navigation instead of page navigation 
+    # K("RC-Left_Brace"): K("C-Page_Up"),      # BracesNav
+    # K("RC-Right_Brace"): K("C-Page_Down"),   # BracesNav
 })
 
 # Open preferences in browsers


### PR DESCRIPTION
Firefox in macOS uses Ctrl+PgUp/PgDn to navigate tabs, while Cmd+Braces is for back/forward page navigation. Since the main goal of Kinto is to emulate macOS shortcuts wherever practical, using the Ctrl+Brace shortcuts for tab navigation should be disabled by default. 

The equivalent for tab navigation would then be Super+PgUp/PgDn, since the physical Ctrl key is Super. 

Proof of concept addition of a tweak item to enable/disable the braces for tab navigation will follow shortly.

Tweak item proof-of-concept in PR #489. 
