### PR TITLE
Open Firefox private window with Ctrl+Shift+N

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -413,6 +413,7 @@ define_keymap(re.compile("Firefox", re.IGNORECASE),{
         K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),
         K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")
     ],
+    K("RC-Shift-N"):    K("RC-Shift-P"),        # Open private window with Ctrl+Shift+N like other browsers
 })
 define_keymap(re.compile(chromeStr, re.IGNORECASE),{
     K("C-comma"): [K("M-e"), K("s"),K("Enter")],

--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -529,6 +529,7 @@ GroupAdd, intellij, ahk_exe idea64.exe
         ; Open preferences
         #IfWinActive ahk_exe firefox.exe
             ^,::send, {Ctrl Down}t{Ctrl Up}about:preferences{Enter}
+            ^+n::send ^+p
         #If
         #IfWinActive ahk_exe chrome.exe
             ^,::send {Alt Down}e{Alt Up}s{Enter}


### PR DESCRIPTION
Safari and Chrome/Chromium use Ctrl+Shift+N to open private/incognito windows. Firefox for some reason wants to use Ctrl+Shift+P. This makes Firefox respond to Ctrl+Shift+N the same way as Safari and the Chromes. Ctrl+Shift+P of course still works also. 

No pre-existing action for Ctrl+Shift+N seems to exist in the current Firefox version. So no known conflict.