### PR TITLE
Toggle maximized window state shortcut (KDE Neon)

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -431,6 +431,7 @@ define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
     K("RC-Space"): K("Alt-F1"),                   # Default SL - Launch Application Menu (gnome/kde)
     K("RC-F3"):K("Super-d"),                      # Default SL - Show Desktop (gnome/kde,eos)
     K("RC-Super-f"):K("M-F10"),                   # Default SL - Maximize app (gnome/kde)
+    # K("RC-Super-f"): K("Super-Page_Up"),          # SL - Toggle maximized window state (kde_neon)
     # K("Super-Right"):K("C-M-Right"),              # Default SL - Change workspace (budgie)
     # K("Super-Left"):K("C-M-Left"),                # Default SL - Change workspace (budgie)
     K("RC-Q"): K("M-F4"),                         # Default SL - not-popos


### PR DESCRIPTION
Putting this in as disabled. It will need some logic in the installer to enable it if Neon is detected, and disable the `(gnome/kde)` line above it. But at least it will be there already, to be manually enabled if necessary. 

See issue #477 for discussion.