### PR TITLE
Quit Chromes with Cmd+Q, fix Chromes preferences shortcut

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -388,7 +388,27 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
 ### END OF FILE MANAGER GROUP OF KEYMAPS ###
 ############################################
 
-# Keybindings for Browsers
+# Keybindings overrides for Chromes/Chromium browsers 
+# (overrides some shortcuts from General Web Browsers block below)
+define_keymap(re.compile(chromeStr, re.IGNORECASE),{
+    K("RC-comma"): [
+            K("C-t"),K("c"),K("h"),K("r"),K("o"),K("m"),K("e"),K("Shift-Semicolon"),K("Slash"),K("Slash"),
+            K("s"),K("e"),K("t"),K("t"),K("i"),K("n"),K("g"),K("s"),K("Enter")],
+    K("RC-q"): K("M-F4"),
+}, "Overrides for Chrome-based Browsers")
+# Opera C-F12
+
+# Keybindings overrides for Chromes/Chromium browsers 
+# (overrides some shortcuts from General Web Browsers block below)
+define_keymap(re.compile("Firefox", re.IGNORECASE),{
+    K("C-comma"): [
+        K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),
+        K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),
+        K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")
+    ],
+}, "Overrides for Firefox browsers")
+
+# Keybindings for General Web Browsers
 define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Q"): K("RC-Q"),           # Close all browsers Instances
     K("M-RC-I"): K("RC-Shift-I"),   # Dev tools
@@ -402,22 +422,9 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_7"): K("M-Key_7"),
     K("RC-Key_8"): K("M-Key_8"),
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
-    K("C-Left_Brace"): K("C-Page_Up"),
-    K("C-Right_Brace"): K("C-Page_Down"),
-})
-
-# Open preferences in browsers
-define_keymap(re.compile("Firefox", re.IGNORECASE),{
-    K("C-comma"): [
-        K("C-T"),K("a"),K("b"),K("o"),K("u"),K("t"),
-        K("Shift-SEMICOLON"),K("p"),K("r"),K("e"),K("f"),
-        K("e"),K("r"),K("e"),K("n"),K("c"),K("e"),K("s"),K("Enter")
-    ],
-})
-define_keymap(re.compile(chromeStr, re.IGNORECASE),{
-    K("C-comma"): [K("M-e"), K("s"),K("Enter")],
-}, "Browsers")
-# Opera C-F12
+    # K("C-Left_Brace"): K("C-Page_Up"),
+    # K("C-Right_Brace"): K("C-Page_Down"),
+}, "General Web Browsers")
 
 # Note: terminals extends to remotes as well
 define_keymap(lambda wm_class: wm_class.casefold() not in terminals,{

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -398,7 +398,7 @@ define_keymap(re.compile(chromeStr, re.IGNORECASE),{
 }, "Overrides for Chrome-based Browsers")
 # Opera C-F12
 
-# Keybindings overrides for Chromes/Chromium browsers 
+# Keybindings overrides for Firefox browsers 
 # (overrides some shortcuts from General Web Browsers block below)
 define_keymap(re.compile("Firefox", re.IGNORECASE),{
     K("C-comma"): [


### PR DESCRIPTION
Chromes on Linux refuse to respond to Cmd+Q (physical Alt+Q, logical RC+Q under Kinto remapping), so it needs to be mapped to Alt+F4 (M-F4). 

To get Chrome browsers to respond properly to Cmd+Q (Quit), I had to rearrange the order of the `chromeStr` block so that it can take precedence over the more "general" browser block which defines `K("RC-Q"): K("RC-Q"),` and was therefore interfering. 

The preferences shortcut for Chromes was not working, opens the Edit menu but can't proceed further because the "Preferences" item doesn't seem to have a shortcut letter anymore. (Moving through the Edit menu with arrow keys shows no underlined letter in "Preferences" and there is no shortcut visible.) So I implemented a multi-keystroke macro solution modeled on the existing method for opening Firefox preferences. It opens a new tab and just types "chrome://settings" and Enter key. Seems to work just as reliably as the equivalent Firefox preferences shortcut. Possibly better, because it's a bit shorter (enters quicker). Hard to tell. 

Reworked some of the related comments and code block labels based on the Finder mod comments, for clarification of the purpose of each code block in the "browsers" section.