### PR TITLE
Add Station terminal WM_CLASS to terminals list

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -23,6 +23,7 @@ terminals = [
     "qterminal",
     "st",
     "sakura",
+    "station",
     "terminator",
     "termite",
     "tilda",


### PR DESCRIPTION
Nitrux Linux default terminal is called Station, with WM_CLASS name "station".