### PR TITLE
Add qemu-system- WM_CLASS variants to remotes list

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -44,6 +44,7 @@ codeStr = "|".join(str(x) for x in mscodes)
 remotes = [
     "Gnome-boxes",
     "org.remmina.Remmina",
+    "qemu-system-.*",
     "Virt-manager",
     "VirtualBox",
     "VirtualBox Machine",


### PR DESCRIPTION
Adding a regex for variants of `qemu-system-.*` to remotes list to bypass Kinto mapping. This is working for me. 

Variants I've seen on my system: 
`qemu-system-i386`
`qemu-system-x86_64`

A snap package called Sosumi operates as a QEMU/KVM front end, and caused a problem because it wanted to see Control_L+Alt_L+G to let go of mouse and keyboard. This solves that problem.