### PR TITLE
Fix zoom in/out (font size) shortcuts in terminals

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -678,7 +678,7 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     # K("RC-Tab"): K("M-Tab"),                      # Default - Cmd Tab - App Switching Default
     # K("RC-Shift-Tab"): K("M-Shift-Tab"),          # Default - Cmd Tab - App Switching Default
     # Converts Cmd to use Ctrl-Shift
-    K("RC-MINUS"): K("C-Shift-MINUS"),
+    K("RC-MINUS"): K("C-MINUS"),
     K("RC-EQUAL"): K("C-Shift-EQUAL"),
     K("RC-BACKSPACE"): K("C-Shift-BACKSPACE"),
     K("RC-W"): K("C-Shift-W"),


### PR DESCRIPTION
On macOS the terminal, like a web browser, lets you "zoom" in and out with Cmd+Equal and Cmd+Minus. It doesn't force you to type Cmd+Shift+Equal to get to the "Plus" keycode on the Equal key. On Linux of course, terminals want you to use Ctrl+Shift+Equal (Plus) to zoom in (increase font size) and then Ctrl+Minus without the Shift key to decrease the font size (zoom out). This is very awkward. 

Mapping RC-Minus to C-Minus in the termStr block instead of to C-Shift-Minus lets the user zoom in and out in terminals by just pressing the equivalent of Cmd-(Equal/Minus) keys, without ever worrying about the Shift key. Same as terminals in macOS, and GUI web browsers. 

Since this is probably just one of the keys that was blanket remapped from RC to C-Shift, I don't know of any reason this should be harmful.