### PR TITLE
Add Cmd+Opt+Left/Right and Cmd+Shift+Braces for browser tab navigation

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -408,11 +408,16 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_7"): K("M-Key_7"),
     K("RC-Key_8"): K("M-Key_8"),
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
-    K("RC-M-Left"):     K("C-Page_Up"),         # Go to prior tab
-    K("RC-M-Right"):    K("C-Page_Down"),       # Go to next tab
-    K("Super-Page_Up"):     K("C-Page_Up"),     # Go to prior tab
-    K("Super-Page_Down"):   K("C-Page_Down"),   # Go to next tab
-    # Use brace keys for tab navigation instead of page navigation 
+    # Enable Cmd+Shift+Braces for tab navigation
+    K("RC-Shift-Left_Brace"):   K("C-Page_Up"),     # Go to prior tab
+    K("RC-Shift-Right_Brace"):  K("C-Page_Down"),   # Go to next tab
+    # Enable Cmd+Option+Left/Right for tab navigation
+    K("RC-M-Left"):             K("C-Page_Up"),     # Go to prior tab
+    K("RC-M-Right"):            K("C-Page_Down"),   # Go to next tab
+    # Enable Ctrl+PgUp/PgDn for tab navigation
+    K("Super-Page_Up"):         K("C-Page_Up"),     # Go to prior tab
+    K("Super-Page_Down"):       K("C-Page_Down"),   # Go to next tab
+    # Use Cmd+Braces keys for tab navigation instead of page navigation 
     # K("C-Left_Brace"): K("C-Page_Up"),
     # K("C-Right_Brace"): K("C-Page_Down"),
 }, "General Web Browsers")

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -394,7 +394,7 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
 ### END OF FILE MANAGER GROUP OF KEYMAPS ###
 ############################################
 
-# Keybindings for Browsers
+# Keybindings for General Web Browsers
 define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Q"): K("RC-Q"),           # Close all browsers Instances
     K("M-RC-I"): K("RC-Shift-I"),   # Dev tools
@@ -408,9 +408,15 @@ define_keymap(re.compile(browserStr, re.IGNORECASE),{
     K("RC-Key_7"): K("M-Key_7"),
     K("RC-Key_8"): K("M-Key_8"),
     K("RC-Key_9"): K("M-Key_9"),    # Jump to last tab
-    K("C-Left_Brace"): K("C-Page_Up"),
-    K("C-Right_Brace"): K("C-Page_Down"),
-})
+    K("RC-M-Left"):     K("C-Page_Up"),         # Go to prior tab
+    K("RC-M-Right"):    K("C-Page_Down"),       # Go to next tab
+    K("Super-Page_Up"):     K("C-Page_Up"),     # Go to prior tab
+    K("Super-Page_Down"):   K("C-Page_Down"),   # Go to next tab
+    # Use brace keys for tab navigation instead of page navigation 
+    # K("C-Left_Brace"): K("C-Page_Up"),
+    # K("C-Right_Brace"): K("C-Page_Down"),
+}, "General Web Browsers")
+
 
 # Open preferences in browsers
 define_keymap(re.compile("Firefox", re.IGNORECASE),{

--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -536,6 +536,13 @@ GroupAdd, intellij, ahk_exe idea64.exe
 
     ; Close all browsers
     #IfWinActive ahk_group browsers
+        ;Tab Navigation
+        ^+[::send ^{PgUp}
+        ^+]::send ^{PgDn}
+        ^!Left::send ^{PgUp}
+        ^!Right::send ^{PgDn}
+        #Left::send ^{PgUp}
+        #Right::send ^{PgDn}
         ^q::send {Alt Down}f{Alt Up}x   ; exit all windows
         ; Dev Tools
         !^i::send {Ctrl Down}{Shift Down}i{Shift Up}{Ctrl Up}


### PR DESCRIPTION
Adding mapping to enable Cmd+Opt+Left/Right to supplement Ctrl+PgUp/PgDn for browser tab navigation. 

Shortcut is verified by testing to work on Firefox, Google Chrome and Opera in macOS, so it should be suitable for inclusion in Kinto. 

Included are some line changes from PR #487, which should close that PR if this is merged.