### PR TITLE
Fix for toggling between Chrome/IBM/Windows/Mac on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,13 @@ def windows_setup():
 		print("Copying autohotkey combinations for Terminals & Editors...")
 		os.system('copy /Y "' + path + '\\windows\\kinto.ahk" "' + path + '\\windows\\kinto-new.ahk"')
 	if default < 3:
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default)(?!( - ST2CODE))(.*)/$2$3$5/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default)(?!( - ST2CODE))(.*)/$2$3$5/gm" .\\windows\\kinto-new.ahk')
 	if default == 1:
 		kbtype = "mac"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; MacModifiers)/$2$3/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; MacModifiers)/$2$3/gm" .\\windows\\kinto-new.ahk')
 	elif default == 2:
 		kbtype = "win"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers)/$2$3/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers)/$2$3/gm" .\\windows\\kinto-new.ahk')
 	elif default == 5:
 		print("Removing any old registry keys from prior versions...")
 		p = subprocess.Popen(['powershell.exe', "Remove-ItemProperty -Path HKLM:'SYSTEM\CurrentControlSet\Control\Keyboard Layout' -Name 'Scancode Map' -ErrorAction SilentlyContinue"], stdout=sys.stdout)
@@ -52,25 +52,25 @@ def windows_setup():
 		print("Uninstall of Kinto is Complete.")
 	if default == 3:
 		kbtype = "chrome"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Chromebook)/$2$3/g" .\\windows\\kinto-new.ahk')
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers/CB)/$2$3/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Chromebook)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB)/$2$3/gm" .\\windows\\kinto-new.ahk')
 	if default == 3 or default == 4:
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB\/IBM)/$2$3/g" .\\windows\\kinto-new.ahk')
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB\/IBM)/$2$3/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB\/IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB\/IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
 	if default == 4:
 		kbtype = "ibm"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; IBM)/$2$3/g" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
 	if default > 0 and default < 5:
 		stvscode = yn_choice(bcolors.CYELLOW2 + "Would you like to use Sublime Text 3 keymaps in VS Code?\n" + bcolors.ENDC)
 		print("\nWill now install Ubuntu Terminal Theme as default...")
 		os.system('regedit "' + path + '\\windows\\theme_ubuntu.reg"')
 		os.system('robocopy "'+ path + '\\assets" "%userprofile%\\.kinto\\assets" /E')
 		if (stvscode and (default > 0 or default < 3)):
-			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default - ST2CODE)/$2$3/g" .\\windows\\kinto-new.ahk')
+			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default - ST2CODE)/$2$3/gm" .\\windows\\kinto-new.ahk')
 		elif (stvscode and (default == 3 or default == 4 )):
-			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB/IBM - ST2CODE)/$2$3/g" .\\windows\\kinto-new.ahk')
+			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB/IBM - ST2CODE)/$2$3/gm" .\\windows\\kinto-new.ahk')
 		os.system('copy /Y "' + path + '\\windows\\kinto-start.vbs" "%userprofile%\\.kinto\\kinto-start.vbs"')
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/{kbtype}/' + kbtype + '/g" "%userprofile%\\.kinto\\kinto-start.vbs"')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/{kbtype}/' + kbtype + '/gm" "%userprofile%\\.kinto\\kinto-start.vbs"')
 		os.system('copy /Y "' + path + '\\windows\\usb.vbs" "%userprofile%\\.kinto\\usb.vbs"')
 		os.system('copy /Y "' + path + '\\windows\\detectUSB.ahk" "%userprofile%\\.kinto\\detectUSB.ahk"')
 		os.system('mklink "%userprofile%\\AppData\\Roaming\\Microsoft\\Windows\\STARTM~1\\Programs\\Startup\\kinto-start.vbs" "%userprofile%\\.kinto\\kinto-start.vbs"')

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,15 @@ def windows_setup():
 		print("This install will fail if you are not running with elevated privileges")
 		os.system('powershell -executionpolicy bypass ".\\windows\\autohotkey.ps1"')
 		print("Copying autohotkey combinations for Terminals & Editors...")
-		os.system('copy /Y "' + path + '\\windows\\kinto.ahk" "' + path + '\\windows\\kinto-new.ahk"')
+		os.system('copy /Y "' + path + '\\windows\\kinto.ahk" "' + homedir + '\\kinto-new.ahk"')
 	if default < 3:
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default)(?!( - ST2CODE))(.*)/$2$3$5/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default)(?!( - ST2CODE))(.*)/$2$3$5/gm" ' + homedir + '\\kinto-new.ahk')
 	if default == 1:
 		kbtype = "mac"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; MacModifiers)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; MacModifiers)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 	elif default == 2:
 		kbtype = "win"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 	elif default == 5:
 		print("Removing any old registry keys from prior versions...")
 		p = subprocess.Popen(['powershell.exe', "Remove-ItemProperty -Path HKLM:'SYSTEM\CurrentControlSet\Control\Keyboard Layout' -Name 'Scancode Map' -ErrorAction SilentlyContinue"], stdout=sys.stdout)
@@ -52,23 +52,23 @@ def windows_setup():
 		print("Uninstall of Kinto is Complete.")
 	if default == 3:
 		kbtype = "chrome"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Chromebook)/$2$3/gm" .\\windows\\kinto-new.ahk')
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Chromebook)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 	if default == 3 or default == 4:
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB\/IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB\/IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB\/IBM)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; WinModifiers\/CB\/IBM)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 	if default == 4:
 		kbtype = "ibm"
-		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; IBM)/$2$3/gm" .\\windows\\kinto-new.ahk')
+		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; IBM)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 	if default > 0 and default < 5:
 		stvscode = yn_choice(bcolors.CYELLOW2 + "Would you like to use Sublime Text 3 keymaps in VS Code?\n" + bcolors.ENDC)
 		print("\nWill now install Ubuntu Terminal Theme as default...")
 		os.system('regedit "' + path + '\\windows\\theme_ubuntu.reg"')
 		os.system('robocopy "'+ path + '\\assets" "%userprofile%\\.kinto\\assets" /E')
 		if (stvscode and (default > 0 or default < 3)):
-			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default - ST2CODE)/$2$3/gm" .\\windows\\kinto-new.ahk')
+			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; Default - ST2CODE)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 		elif (stvscode and (default == 3 or default == 4 )):
-			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB/IBM - ST2CODE)/$2$3/gm" .\\windows\\kinto-new.ahk')
+			os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/(; )(.*)(; CB/IBM - ST2CODE)/$2$3/gm" ' + homedir + '\\kinto-new.ahk')
 		os.system('copy /Y "' + path + '\\windows\\kinto-start.vbs" "%userprofile%\\.kinto\\kinto-start.vbs"')
 		os.system('C:\\Strawberry\\perl\\bin\\perl.exe -pi -e "s/{kbtype}/' + kbtype + '/gm" "%userprofile%\\.kinto\\kinto-start.vbs"')
 		os.system('copy /Y "' + path + '\\windows\\usb.vbs" "%userprofile%\\.kinto\\usb.vbs"')
@@ -76,8 +76,8 @@ def windows_setup():
 		os.system('mklink "%userprofile%\\AppData\\Roaming\\Microsoft\\Windows\\STARTM~1\\Programs\\Startup\\kinto-start.vbs" "%userprofile%\\.kinto\\kinto-start.vbs"')
 		os.system('copy /Y "'+ path + '\\windows\\NoShell.vbs" "%userprofile%\\.kinto\\NoShell.vbs"')
 		os.system('copy /Y "'+ path + '\\windows\\toggle_kb.bat" "%userprofile%\\.kinto\\toggle_kb.bat"')
-		os.system('copy /Y "'+ path + '\\windows\\kinto-new.ahk" "%userprofile%\\.kinto\\kinto.ahk"')
-		os.system("del /f .\\windows\\kinto-new.ahk")
+		os.system('copy /Y "'+ homedir + '\\kinto-new.ahk" "%userprofile%\\.kinto\\kinto.ahk"')
+		os.system("del /f " + homedir + "\\kinto-new.ahk")
 		os.system("del \"C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\StartUp\\kinto.ahk\" 2> nul")
 		userpath = cmdline('cmd /c for %A in ("%userprofile%") do @echo %~sA')[:-1]
 		print('Starting... "' + userpath + '\\AppData\\Roaming\\Microsoft\\Windows\\STARTM~1\\Programs\\Startup\\kinto-start.vbs"')

--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -743,45 +743,45 @@ GroupAdd, intellij, ahk_exe idea64.exe
         ; Clear Terminal and Scroll Buffer
         ^k::Send clear && printf '\e[3J'{Enter}
         ; Remap Physical Ctrl back to Ctrl
-        #0::Send {LCtrl down}0{Ctrl up}  ; Default
-        #1::Send {LCtrl down}1{Ctrl up}  ; Default
-        #2::Send {LCtrl down}2{Ctrl up}  ; Default
-        #3::Send {LCtrl down}3{Ctrl up}  ; Default
-        #4::Send {LCtrl down}4{Ctrl up}  ; Default
-        #5::Send {LCtrl down}5{Ctrl up}  ; Default
-        #6::Send {LCtrl down}6{Ctrl up}  ; Default
-        #7::Send {LCtrl down}7{Ctrl up}  ; Default
-        #8::Send {LCtrl down}8{Ctrl up}  ; Default
-        #9::Send {LCtrl down}9{Ctrl up}  ; Default
-        #-::Send {LCtrl down}-{Ctrl up}  ; Default
-        #=::Send {LCtrl down}={Ctrl up}  ; Default
-        #`::Send {LCtrl down}`{Ctrl up}  ; Default
-        #a::Send {LCtrl down}a{Ctrl up}  ; Default
-        #b::Send {LCtrl down}b{Ctrl up}  ; Default
-        #c::Send {LCtrl down}c{Ctrl up}  ; Default
-        #d::Send {LCtrl down}d{Ctrl up}  ; Default
-        #e::Send {LCtrl down}e{Ctrl up}  ; Default
-        #f::Send {LCtrl down}f{Ctrl up}  ; Default
-        #g::Send {LCtrl down}g{Ctrl up}  ; Default
-        #h::Send {LCtrl down}h{Ctrl up}  ; Default
-        #i::Send {LCtrl down}i{Ctrl up}  ; Default
-        #j::Send {LCtrl down}j{Ctrl up}  ; Default
-        #k::Send {LCtrl down}k{Ctrl up}  ; Default
-        #l::Send {LCtrl down}l{Ctrl up}  ; Default
-        #m::Send {LCtrl down}m{Ctrl up}  ; Default
-        #n::Send {LCtrl down}n{Ctrl up}  ; Default
-        #o::Send {LCtrl down}o{Ctrl up}  ; Default
-        #p::Send {LCtrl down}p{Ctrl up}  ; Default
-        #q::Send {LCtrl down}q{Ctrl up}  ; Default
-        #r::Send {LCtrl down}r{Ctrl up}  ; Default
-        #s::Send {LCtrl down}s{Ctrl up}  ; Default
-        #t::Send {LCtrl down}t{Ctrl up}  ; Default
-        #u::Send {LCtrl down}u{Ctrl up}  ; Default
-        #v::Send {LCtrl down}v{Ctrl up}  ; Default
-        #w::Send {LCtrl down}w{Ctrl up}  ; Default
-        #x::Send {LCtrl down}x{Ctrl up}  ; Default
-        #y::Send {LCtrl down}y{Ctrl up}  ; Default
-        #z::Send {LCtrl down}z{Ctrl up}  ; Default
+        ; #0::Send {LCtrl down}0{Ctrl up}  ; Default
+        ; #1::Send {LCtrl down}1{Ctrl up}  ; Default
+        ; #2::Send {LCtrl down}2{Ctrl up}  ; Default
+        ; #3::Send {LCtrl down}3{Ctrl up}  ; Default
+        ; #4::Send {LCtrl down}4{Ctrl up}  ; Default
+        ; #5::Send {LCtrl down}5{Ctrl up}  ; Default
+        ; #6::Send {LCtrl down}6{Ctrl up}  ; Default
+        ; #7::Send {LCtrl down}7{Ctrl up}  ; Default
+        ; #8::Send {LCtrl down}8{Ctrl up}  ; Default
+        ; #9::Send {LCtrl down}9{Ctrl up}  ; Default
+        ; #-::Send {LCtrl down}-{Ctrl up}  ; Default
+        ; #=::Send {LCtrl down}={Ctrl up}  ; Default
+        ; #`::Send {LCtrl down}`{Ctrl up}  ; Default
+        ; #a::Send {LCtrl down}a{Ctrl up}  ; Default
+        ; #b::Send {LCtrl down}b{Ctrl up}  ; Default
+        ; #c::Send {LCtrl down}c{Ctrl up}  ; Default
+        ; #d::Send {LCtrl down}d{Ctrl up}  ; Default
+        ; #e::Send {LCtrl down}e{Ctrl up}  ; Default
+        ; #f::Send {LCtrl down}f{Ctrl up}  ; Default
+        ; #g::Send {LCtrl down}g{Ctrl up}  ; Default
+        ; #h::Send {LCtrl down}h{Ctrl up}  ; Default
+        ; #i::Send {LCtrl down}i{Ctrl up}  ; Default
+        ; #j::Send {LCtrl down}j{Ctrl up}  ; Default
+        ; #k::Send {LCtrl down}k{Ctrl up}  ; Default
+        ; #l::Send {LCtrl down}l{Ctrl up}  ; Default
+        ; #m::Send {LCtrl down}m{Ctrl up}  ; Default
+        ; #n::Send {LCtrl down}n{Ctrl up}  ; Default
+        ; #o::Send {LCtrl down}o{Ctrl up}  ; Default
+        ; #p::Send {LCtrl down}p{Ctrl up}  ; Default
+        ; #q::Send {LCtrl down}q{Ctrl up}  ; Default
+        ; #r::Send {LCtrl down}r{Ctrl up}  ; Default
+        ; #s::Send {LCtrl down}s{Ctrl up}  ; Default
+        ; #t::Send {LCtrl down}t{Ctrl up}  ; Default
+        ; #u::Send {LCtrl down}u{Ctrl up}  ; Default
+        ; #v::Send {LCtrl down}v{Ctrl up}  ; Default
+        ; #w::Send {LCtrl down}w{Ctrl up}  ; Default
+        ; #x::Send {LCtrl down}x{Ctrl up}  ; Default
+        ; #y::Send {LCtrl down}y{Ctrl up}  ; Default
+        ; #z::Send {LCtrl down}z{Ctrl up}  ; Default
         ; !0::Send {LCtrl down}0{Ctrl up}  ; CB/IBM
         ; !1::Send {LCtrl down}1{Ctrl up}  ; CB/IBM
         ; !2::Send {LCtrl down}2{Ctrl up}  ; CB/IBM


### PR DESCRIPTION
Due to improper regex the switching between Chrome and IBM layouts could break the toggling btwn Windows and Mac. Windows and mac toggling was fine but could be permanently screwed up if changed to the other 2 formats and back again.

Future revisions ought to remove the regex entirely, but for now this will fix the current design.