### PR TITLE
Add Cmd+Shift+Braces for tab navigation in file managers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -318,8 +318,8 @@ define_keymap(re.compile("pcmanfm|pcmanfm-qt", re.IGNORECASE),{
 define_keymap(re.compile("spacefm", re.IGNORECASE),{
     K("RC-Page_Up"): K("C-Shift-Tab"),              # Go to prior tab
     K("RC-Page_Down"): K("C-Tab"),                  # Go to next tab
-    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"),              # Go to prior tab
-    K("RC-Shift-Right_Brace"): K("C-Tab"),                  # Go to next tab
+    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"),     # Go to prior tab
+    K("RC-Shift-Right_Brace"): K("C-Tab"),          # Go to next tab
     K("RC-Shift-N"): [K("RC-F")],	                # Create new folder is Ctrl+F by default
     K("RC-Backspace"): [K("Delete"),K("Enter")],	# Move to Trash (delete, bypass dialog)
     K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -316,6 +316,10 @@ define_keymap(re.compile("pcmanfm|pcmanfm-qt", re.IGNORECASE),{
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("spacefm", re.IGNORECASE),{
+    K("RC-Page_Up"): K("C-Shift-Tab"),              # Go to prior tab
+    K("RC-Page_Down"): K("C-Tab"),                  # Go to next tab
+    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"),              # Go to prior tab
+    K("RC-Shift-Right_Brace"): K("C-Tab"),                  # Go to next tab
     K("RC-Shift-N"): [K("RC-F")],	                # Create new folder is Ctrl+F by default
     K("RC-Backspace"): [K("Delete"),K("Enter")],	# Move to Trash (delete, bypass dialog)
     K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
@@ -376,6 +380,8 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     # K("RC-Down"): K("M-Down"),              # Go Down dir (only works on folders) [not universal]
     # K("RC-Down"): K("RC-O"),                # Go Down dir (open folder/file) [not universal]
     K("RC-Down"): K("Enter"),               # Go Down dir (open folder/file) [universal]
+    K("RC-Shift-Left_Brace"): K("C-Page_Up"),       # Go to prior tab
+    K("RC-Shift-Right_Brace"): K("C-Page_Down"),    # Go to next tab
     ###########################################################################################################
     ###  Open in New Window | Move to Trash | Duplicate file/folder                                         ###
     ###########################################################################################################


### PR DESCRIPTION
This adds Cmd+Shift+Braces as an option for tab navigation in most Linux file managers. Also fixes the standard tab navigation shortcuts (Ctrl+PgUp/PgDn) to work in SpaceFM. 

This shortcut works in Finder on macOS. 

Tested this code in: 

Caja
Dolphin
Nautilus
Nemo
PCManFM[-Qt]
SpaceFM (default is Ctrl+Tab/Ctrl+Shift+Tab, now remapping from Ctrl+PgUp/PgDn)
Thunar