### PR TITLE
bugfix: inputing semicolon on alt+up/down

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -308,8 +308,8 @@ GroupAdd, intellij, ahk_exe idea64.exe
     !Esc::SendInput, {Pause}
 
     ; Go up or down a page
-    $!Down::Send {PgDn};
-    $!Up::Send {PgUp};
+    $!Down::Send {PgDn}
+    $!Up::Send {PgUp}
 
     ; Close Apps 
     ^q::Send !{F4}


### PR DESCRIPTION
when ALT  + UpArrow or ALT + DownArrow
semicolon is inputed after PgUp / PgDown