### PR TITLE
Add support for Firefox Developer Edition

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -64,6 +64,7 @@ browsers = [
     "Discord",
     "Epiphany",
     "Firefox",
+    "Firefox Developer Edition",
     "Google-chrome",
     "microsoft-edge",
     "microsoft-edge-dev",


### PR DESCRIPTION
I made this change `~/.config/kinto/kinto.py` and restarted the service. Then cmd-option-left/right worked in Firefox Developer Edition as well – https://github.com/rbreaves/kinto/issues/535#issuecomment-917612176

I’m quite new to Kinto so I’m not 100% sure this is the correct fix, but it seems to work.

Thanks for Kinto btw! It’s awesome.