### PR TITLE
Add WM_CLASS for Spicy to remotes list

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -46,6 +46,7 @@ remotes = [
     "org.remmina.Remmina",
     "remmina",
     "qemu-system-.*",
+    "Spicy",
     "Virt-manager",
     "VirtualBox",
     "VirtualBox Machine",


### PR DESCRIPTION
Playing with QuickEMU. It uses QEMU but the main window has a WM_CLASS of "Spicy" so isn't caught by the "qemu" entry. Adding it to the list of VM-type software.