### PR TITLE
Add new terminal Tabby

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -24,6 +24,7 @@ terminals = [
     "st",
     "sakura",
     "station",
+    "tabby",
     "terminator",
     "termite",
     "tilda",


### PR DESCRIPTION
This app (Tabby, used to be Terminus) is heavy and has some really strange behaviors with keyboard shortcuts, but that doesn't seem to actually be a problem with Kinto's remapping. Tabby behaves equally strangely with Kinto disabled. Very slow to react to keyboard shortcuts in general and often requires hitting holding down the modifier and hitting the last key a second time. 

Might be a peculiarity specific to having it installed on my Ubuntu/GNOME 21.10 system. It's a cross-platform terminal app. Might want to check it out on Windows and see if it should be added to the Windows Kinto config file.