### PR TITLE
Shortcut for LibreOffice Find and Replace dialog

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -449,6 +449,17 @@ define_keymap(re.compile(chromeStr, re.IGNORECASE),{
 }, "Browsers")
 # Opera C-F12
 
+define_keymap(re.compile("libreoffice*", re.IGNORECASE),{
+    # K("RC-M-f"):                K("C-h"),           # Find & Replace dialog (LibreOffice for macOS)
+    # Uncomment the line above to enable the official LibreOffice for macOS shortcut
+    K("RC-Shift-h"):            K("C-h"),           # Find & Replace dialog (Microsoft Excel for macOS)
+    # LibreOffice for macOS uses Cmd+Option+F, Excel for macOS uses Cmd+Shift+H
+    # Alternatives are required to avoid conflicting with Cmd+H (Hide Window)
+    # Ctrl+Alt+F is useful as a system shortcut to open a file browser, 
+    # so Excel's Ctrl+Shift+H is also mapped here as an alternative. 
+    # 
+},"LibreOffice")
+
 define_keymap(re.compile("ulauncher", re.IGNORECASE),{
     K("RC-Key_1"):      K("M-Key_1"),      # Remap Ctrl+[1-9] and Ctrl+[a-z] to Alt+[1-9] and Alt+[a-z]
     K("RC-Key_2"):      K("M-Key_2"),


### PR DESCRIPTION
Shortcut for the Find & Replace dialog in both LibreOffice and Microsoft Excel in Windows or Linux is Ctrl+H. This conflicts with the remapped Cmd+H (Ctrl+H) shortcut used by macOS for Hide Window. 

Excel on macOS resolves the conflict with Cmd+H by using Cmd+Shift+H as an alternative. 

LibreOffice on macOS resolves the conflict with Cmd+H by using Cmd+Option+F, unlike Excel. (Ctrl+Alt+F on a Kinto remapped PC keyboard.) 

The Ctrl+Alt+F shortcut is useful as a system shortcut to open a file browser window, as a match for the common system shortcut of Ctrl+Alt+T to open a terminal window. I am therefore leaving that line commented out by default here, and choosing instead to enable the shortcut that matches Excel, which more users coming from macOS to Linux will probably be familiar with. 

So the remapping that will be enabled by default in all LibreOffice apps with this change is the equivalent of Cmd+Shift+H (Ctrl+Shift+H) to Ctrl+H to activate the Find & Replace dialog.