### PR TITLE
Finder mods updates: Nav, Views

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -390,8 +390,8 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     ###########################################################################################################
     ###  Navigation                                                                                         ###
     ###########################################################################################################
-    K("RC-Left_Brace"):         K("M-Left"),        # Go to prior tab
-    K("RC-Right_Brace"):        K("M-Right"),       # Go to next tab
+    K("RC-Left_Brace"):         K("M-Left"),        # Go Back
+    K("RC-Right_Brace"):        K("M-Right"),       # Go Forward
     K("RC-Left"):               K("M-Left"),        # Go Back
     K("RC-Right"):              K("M-Right"),       # Go Forward
     K("RC-Up"):                 K("M-Up"),          # Go Up dir

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -272,17 +272,17 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("caja", re.IGNORECASE),{
     # K("RC-Super-o"): K("RC-Shift-Enter"),       # Open in new tab
-    K("RC-Super-o"): K("RC-Shift-W"),           # Open in new window
+    K("RC-Super-o"):    K("RC-Shift-W"),        # Open in new window
 },"Overrides for Caja - Finder Mods")
 
 # Keybindings overrides for DDE (Deepin) File Manager
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("dde-file-manager", re.IGNORECASE),{
-    K("RC-i"): K("RC-i"),                       # File properties dialog (Get Info)
-    K("RC-comma"): None,                        # Disable preferences shortcut (no shortcut available)
-    K("RC-Up"): K("RC-Up"),                     # Go Up dir
-    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"), # Go to prior tab
-    K("RC-Shift-Right_Brace"): K("C-Tab"),      # Go to next tab
+    K("RC-i"):                  K("RC-i"),          # File properties dialog (Get Info)
+    K("RC-comma"):              None,               # Disable preferences shortcut (no shortcut available)
+    K("RC-Up"):                 K("RC-Up"),         # Go Up dir
+    K("RC-Shift-Left_Brace"):   K("C-Shift-Tab"),   # Go to prior tab
+    K("RC-Shift-Right_Brace"):  K("C-Tab"),         # Go to next tab
 },"Overrides for DDE File Manager - Finder Mods")
 
 # Keybindings overrides for Dolphin
@@ -297,15 +297,15 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     ### "Open in new tab" requires manually setting custom shortcut of Ctrl+Shift+o in
     ### Dolphin's keyboard shortcuts. There is no default shortcut set for this function.
     ##########################################################################################
-    K("RC-Super-o"): K("RC-Shift-o"),           # Open in new window (or new tab, user's choice, see above)
-    K("RC-Shift-N"): K("F10"),                  # Create new folder
-    K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
+    K("RC-Super-o"):    K("RC-Shift-o"),        # Open in new window (or new tab, user's choice, see above)
+    K("RC-Shift-N"):    K("F10"),               # Create new folder
+    K("RC-comma"):      K("RC-Shift-comma"),    # Open preferences dialog
 },"Overrides for Dolphin - Finder Mods")
 
 # Keybindings overrides for elementary OS Files (Pantheon)
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
-    # K("RC-Super-o"): K("Shift-Enter"),          # Open folder in new tab
+    # K("RC-Super-o"):    K("Shift-Enter"),       # Open folder in new tab
     K("RC-comma"): None,                        # Disable preferences shortcut since none available
 },"Overrides for Pantheon - Finder Mods")
 
@@ -317,28 +317,28 @@ define_keymap(re.compile("org.gnome.nautilus|nautilus", re.IGNORECASE),{
     # to run command: "nautilus --new-window /home/USER" [ replace "USER" ]
     K("RC-KEY_1"):      K("C-KEY_2"),           # View as Icons
     K("RC-KEY_2"):      K("C-KEY_1"),           # View as List (Detailed)
-    K("RC-Super-o"): K("Shift-Enter"),          # Open in new window
-    # K("RC-Super-o"): K("RC-Enter"),             # Open in new tab
-    K("RC-comma"): K("RC-comma"),               # Overrides "Open preferences dialog" shortcut below	
+    K("RC-Super-o"):    K("Shift-Enter"),       # Open in new window
+    # K("RC-Super-o"):    K("RC-Enter"),          # Open in new tab
+    K("RC-comma"):      K("RC-comma"),          # Overrides "Open preferences dialog" shortcut below	
 },"Overrides for Nautilus - Finder Mods")
 
 # Keybindings overrides for PCManFM and PCManFM-Qt
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("pcmanfm|pcmanfm-qt", re.IGNORECASE),{
     K("RC-KEY_2"):      K("C-KEY_4"),               # View as List (Detailed) [Not in PCManFM-Qt]
-    K("RC-Backspace"): [K("Delete"),K("Enter")],    # Move to Trash (delete, bypass dialog)
+    K("RC-Backspace"):  [K("Delete"),K("Enter")],   # Move to Trash (delete, bypass dialog)
 },"Overrides for PCManFM - Finder Mods")
 
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("spacefm", re.IGNORECASE),{
-    K("RC-Page_Up"): K("C-Shift-Tab"),              # Go to prior tab
-    K("RC-Page_Down"): K("C-Tab"),                  # Go to next tab
-    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"),     # Go to prior tab
-    K("RC-Shift-Right_Brace"): K("C-Tab"),          # Go to next tab
-    K("RC-Shift-N"): [K("RC-F")],	                # Create new folder is Ctrl+F by default
-    K("RC-Backspace"): [K("Delete"),K("Enter")],	# Move to Trash (delete, bypass dialog)
-    K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
+    K("RC-Page_Up"):            K("C-Shift-Tab"),           # Go to prior tab
+    K("RC-Page_Down"):          K("C-Tab"),                 # Go to next tab
+    K("RC-Shift-Left_Brace"):   K("C-Shift-Tab"),           # Go to prior tab
+    K("RC-Shift-Right_Brace"):  K("C-Tab"),                 # Go to next tab
+    K("RC-Shift-N"):            K("RC-F"),	                # Create new folder is Ctrl+F by default
+    K("RC-Backspace"):          [K("Delete"),K("Enter")],   # Move to Trash (delete, bypass dialog)
+    K("RC-comma"):              [K("M-V"),K("p")],          # Overrides "Open preferences dialog" shortcut below
     # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences.
     # SpaceFM seems to be doing some nasty binding that blocks things like Alt+Tab while the menu is open.
 },"Overrides for SpaceFM - Finder Mods")
@@ -346,8 +346,8 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
 # Keybindings overrides for Thunar
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
-    K("RC-Super-o"): K("RC-Shift-P"),          # Open in new tab
-    K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
+    K("RC-Super-o"):    K("RC-Shift-P"),            # Open in new tab
+    K("RC-comma"):      [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
 },"Overrides for Thunar - Finder Mods")
 
 filemanagers = [
@@ -414,10 +414,6 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     # K("RC-Shift-Enter"):    K("Enter"),         # Remap alternative "Enter" key to easily activate/exit text fields
     # K("RC-Shift-Enter"):    K("F2"),            # Rename with Cmd+Shift+Enter
 },"General File Managers - Finder Mods")
-
-############################################
-### END OF FILE MANAGER GROUP OF KEYMAPS ###
-############################################
 
 ############################################
 ### END OF FILE MANAGER GROUP OF KEYMAPS ###

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -273,19 +273,23 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
 define_keymap(re.compile("caja", re.IGNORECASE),{
     # K("RC-Super-o"): K("RC-Shift-Enter"),       # Open in new tab
     K("RC-Super-o"): K("RC-Shift-W"),           # Open in new window
-},"Overrides for Caja - Finder")
+},"Overrides for Caja - Finder Mods")
 
 # Keybindings overrides for DDE (Deepin) File Manager
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("dde-file-manager", re.IGNORECASE),{
-    K("RC-i"): K("RC-i"),                   # File properties dialog (Get Info)
-    K("RC-comma"): None,                    # Disable preferences shortcut (no shortcut available)
-    K("RC-Up"): K("RC-Up"),                 # Go Up dir
-},"Overrides for DDE File Manager - Finder")
+    K("RC-i"): K("RC-i"),                       # File properties dialog (Get Info)
+    K("RC-comma"): None,                        # Disable preferences shortcut (no shortcut available)
+    K("RC-Up"): K("RC-Up"),                     # Go Up dir
+    K("RC-Shift-Left_Brace"): K("C-Shift-Tab"), # Go to prior tab
+    K("RC-Shift-Right_Brace"): K("C-Tab"),      # Go to next tab
+},"Overrides for DDE File Manager - Finder Mods")
 
 # Keybindings overrides for Dolphin
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("dolphin", re.IGNORECASE),{
+    K("RC-KEY_2"):      K("C-KEY_3"),           # View as List (Detailed)
+    K("RC-KEY_3"):      K("C-KEY_2"),           # View as List (Compact)
     ##########################################################################################
     ### "Open in new window" requires manually setting custom shortcut of Ctrl+Shift+o
     ### in Dolphin's keyboard shortcuts. There is no default shortcut set for this function.
@@ -296,28 +300,34 @@ define_keymap(re.compile("dolphin", re.IGNORECASE),{
     K("RC-Super-o"): K("RC-Shift-o"),           # Open in new window (or new tab, user's choice, see above)
     K("RC-Shift-N"): K("F10"),                  # Create new folder
     K("RC-comma"): K("RC-Shift-comma"),         # Open preferences dialog
-},"Overrides for Dolphin - Finder")
+},"Overrides for Dolphin - Finder Mods")
 
-# Keybindings overrides for elementary OS Files
+# Keybindings overrides for elementary OS Files (Pantheon)
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("io.elementary.files", re.IGNORECASE),{
     # K("RC-Super-o"): K("Shift-Enter"),          # Open folder in new tab
-    K("RC-Comma"): None,                        # Disable preferences shortcut since none available
-},"Overrides for Pantheon - Finder")
+    K("RC-comma"): None,                        # Disable preferences shortcut since none available
+},"Overrides for Pantheon - Finder Mods")
 
 # Keybindings overrides for Nautilus
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("org.gnome.nautilus|nautilus", re.IGNORECASE),{
+    # K("RC-N"): K("C-M-Space"), # macOS Finder search window shortcut Cmd+Option+Space
+    # For this ^^^^^^^^^^^ to work, a custom shortcut must be set up in the Settings app in GNOME 
+    # to run command: "nautilus --new-window /home/USER" [ replace "USER" ]
+    K("RC-KEY_1"):      K("C-KEY_2"),           # View as Icons
+    K("RC-KEY_2"):      K("C-KEY_1"),           # View as List (Detailed)
     K("RC-Super-o"): K("Shift-Enter"),          # Open in new window
     # K("RC-Super-o"): K("RC-Enter"),             # Open in new tab
-    K("RC-comma"): K("RC-comma"),               # Overrides "Open preferences dialog" shortcut below
-},"Overrides for Nautilus - Finder")
+    K("RC-comma"): K("RC-comma"),               # Overrides "Open preferences dialog" shortcut below	
+},"Overrides for Nautilus - Finder Mods")
 
 # Keybindings overrides for PCManFM and PCManFM-Qt
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("pcmanfm|pcmanfm-qt", re.IGNORECASE),{
+    K("RC-KEY_2"):      K("C-KEY_4"),               # View as List (Detailed) [Not in PCManFM-Qt]
     K("RC-Backspace"): [K("Delete"),K("Enter")],    # Move to Trash (delete, bypass dialog)
-},"Overrides for PCManFM - Finder")
+},"Overrides for PCManFM - Finder Mods")
 
 # Keybindings overrides for SpaceFM
 # (overrides some bindings from general file manager code block below)
@@ -331,14 +341,14 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
     K("RC-comma"): [K("M-V"),K("p")],               # Overrides "Open preferences dialog" shortcut below
     # This shortcut ^^^^^^^^^^^^^^^ is not fully working in SpaceFM. Opens "View" menu but not Preferences.
     # SpaceFM seems to be doing some nasty binding that blocks things like Alt+Tab while the menu is open.
-},"Overrides for SpaceFM - Finder")
+},"Overrides for SpaceFM - Finder Mods")
 
 # Keybindings overrides for Thunar
 # (overrides some bindings from general file manager code block below)
 define_keymap(re.compile("thunar", re.IGNORECASE),{
     K("RC-Super-o"): K("RC-Shift-P"),          # Open in new tab
     K("RC-comma"): [K("M-E"),K("E")],          # Overrides "Open preferences dialog" shortcut below
-},"Overrides for Thunar - Finder")
+},"Overrides for Thunar - Finder Mods")
 
 filemanagers = [
     "caja",
@@ -374,33 +384,40 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     ###########################################################################################################
     ###  Show Properties (Get Info) | Open Settings/Preferences | Show/Hide hidden files                    ###
     ###########################################################################################################
-    K("RC-i"): K("M-Enter"),                # File properties dialog (Get Info)
-    K("RC-comma"): [K("M-E"),K("N")],       # Open preferences dialog
-    K("RC-Shift-dot"): K("RC-H"),           # Show/hide hidden files ("dot" files)
+    K("RC-i"):                  K("M-Enter"),       # File properties dialog (Get Info)
+    K("RC-comma"):              [K("M-E"),K("N")],  # Open preferences dialog
+    K("RC-Shift-dot"):          K("RC-H"),          # Show/hide hidden files ("dot" files)
     ###########################################################################################################
     ###  Navigation                                                                                         ###
     ###########################################################################################################
-    K("RC-Left"): K("M-Left"),              # Go Back
-    K("RC-Right"): K("M-Right"),            # Go Forward
-    K("RC-Up"): K("M-Up"),                  # Go Up dir
-    # K("RC-Down"): K("M-Down"),              # Go Down dir (only works on folders) [not universal]
-    # K("RC-Down"): K("RC-O"),                # Go Down dir (open folder/file) [not universal]
-    K("RC-Down"): K("Enter"),               # Go Down dir (open folder/file) [universal]
-    K("RC-Shift-Left_Brace"): K("C-Page_Up"),       # Go to prior tab
-    K("RC-Shift-Right_Brace"): K("C-Page_Down"),    # Go to next tab
+    K("RC-Left_Brace"):         K("M-Left"),        # Go to prior tab
+    K("RC-Right_Brace"):        K("M-Right"),       # Go to next tab
+    K("RC-Left"):               K("M-Left"),        # Go Back
+    K("RC-Right"):              K("M-Right"),       # Go Forward
+    K("RC-Up"):                 K("M-Up"),          # Go Up dir
+    # K("RC-Down"):               K("M-Down"),        # Go Down dir (only works on folders) [not universal]
+    # K("RC-Down"):               K("RC-O"),          # Go Down dir (open folder/file) [not universal]
+    K("RC-Down"):               K("Enter"),         # Go Down dir (open folder/file) [universal]
+    K("RC-Shift-Left_Brace"):   K("C-Page_Up"),     # Go to prior tab
+    K("RC-Shift-Right_Brace"):  K("C-Page_Down"),   # Go to next tab
     ###########################################################################################################
     ###  Open in New Window | Move to Trash | Duplicate file/folder                                         ###
     ###########################################################################################################
-    K("RC-Super-o"): K("RC-Shift-o"),       # Open in new window (or tab, depends on FM setup) [not universal]
-    K("RC-Backspace"): K("Delete"),	        # Move to Trash (delete)
-    K("RC-D"): [K("RC-C"),K("RC-V")],       # Mimic Finder's Duplicate command (Copy, then Paste)
+    K("RC-Super-o"):    K("RC-Shift-o"),        # Open in new window (or tab, depends on FM setup) [not universal]
+    K("RC-Backspace"):  K("Delete"),	        # Move to Trash (delete)
+    K("RC-D"):          [K("RC-C"),K("RC-V")],  # Mimic Finder's Duplicate command (Copy, then Paste)
     ###########################################################################################################
     ###  To enable renaming files with the Enter key, uncomment the two keymapping lines just below this.   ###
     ###  Use Ctrl+Shift+Enter to escape or activate text fields such as "[F]ind" and "[L]ocation" fields.   ###
     ###########################################################################################################
-    # K("Enter"): K("F2"),                    # Rename with Enter key
-    # K("RC-Shift-Enter"): K("Enter"),        # Remap alternative "Enter" key to easily activate/exit text fields
-},"File Managers - Finder")
+    # K("Enter"):             K("F2"),            # Rename with Enter key
+    # K("RC-Shift-Enter"):    K("Enter"),         # Remap alternative "Enter" key to easily activate/exit text fields
+    # K("RC-Shift-Enter"):    K("F2"),            # Rename with Cmd+Shift+Enter
+},"General File Managers - Finder Mods")
+
+############################################
+### END OF FILE MANAGER GROUP OF KEYMAPS ###
+############################################
 
 ############################################
 ### END OF FILE MANAGER GROUP OF KEYMAPS ###

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -281,8 +281,10 @@ define_keymap(re.compile("dde-file-manager", re.IGNORECASE),{
     K("RC-i"):                  K("RC-i"),          # File properties dialog (Get Info)
     K("RC-comma"):              None,               # Disable preferences shortcut (no shortcut available)
     K("RC-Up"):                 K("RC-Up"),         # Go Up dir
-    K("RC-Shift-Left_Brace"):   K("C-Shift-Tab"),   # Go to prior tab
-    K("RC-Shift-Right_Brace"):  K("C-Tab"),         # Go to next tab
+    K("RC-Shift-Left_Brace"):   K("C-Shift-Tab"),           # Go to prior tab
+    K("RC-Shift-Right_Brace"):  K("C-Tab"),                 # Go to next tab
+    K("RC-Shift-Left"):         K("C-Shift-Tab"),           # Go to prior tab
+    K("RC-Shift-Right"):        K("C-Tab"),                 # Go to next tab
 },"Overrides for DDE File Manager - Finder Mods")
 
 # Keybindings overrides for Dolphin
@@ -336,6 +338,8 @@ define_keymap(re.compile("spacefm", re.IGNORECASE),{
     K("RC-Page_Down"):          K("C-Tab"),                 # Go to next tab
     K("RC-Shift-Left_Brace"):   K("C-Shift-Tab"),           # Go to prior tab
     K("RC-Shift-Right_Brace"):  K("C-Tab"),                 # Go to next tab
+    K("RC-Shift-Left"):         K("C-Shift-Tab"),           # Go to prior tab
+    K("RC-Shift-Right"):        K("C-Tab"),                 # Go to next tab
     K("RC-Shift-N"):            K("RC-F"),	                # Create new folder is Ctrl+F by default
     K("RC-Backspace"):          [K("Delete"),K("Enter")],   # Move to Trash (delete, bypass dialog)
     K("RC-comma"):              [K("M-V"),K("p")],          # Overrides "Open preferences dialog" shortcut below
@@ -392,8 +396,6 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     ###########################################################################################################
     K("RC-Left_Brace"):         K("M-Left"),        # Go Back
     K("RC-Right_Brace"):        K("M-Right"),       # Go Forward
-    K("RC-Shift-Left"):         K("M-Left"),        # Go Back
-    K("RC-Shift-Right"):        K("M-Right"),       # Go Forward
     K("RC-Left"):               K("M-Left"),        # Go Back
     K("RC-Right"):              K("M-Right"),       # Go Forward
     K("RC-Up"):                 K("M-Up"),          # Go Up dir
@@ -402,6 +404,8 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     K("RC-Down"):               K("Enter"),         # Go Down dir (open folder/file) [universal]
     K("RC-Shift-Left_Brace"):   K("C-Page_Up"),     # Go to prior tab
     K("RC-Shift-Right_Brace"):  K("C-Page_Down"),   # Go to next tab
+    K("RC-Shift-Left"):         K("C-Page_Up"),     # Go to prior tab
+    K("RC-Shift-Right"):        K("C-Page_Down"),   # Go to next tab
     ###########################################################################################################
     ###  Open in New Window | Move to Trash | Duplicate file/folder                                         ###
     ###########################################################################################################

--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -392,6 +392,8 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     ###########################################################################################################
     K("RC-Left_Brace"):         K("M-Left"),        # Go Back
     K("RC-Right_Brace"):        K("M-Right"),       # Go Forward
+    K("RC-Shift-Left"):         K("M-Left"),        # Go Back
+    K("RC-Shift-Right"):        K("M-Right"),       # Go Forward
     K("RC-Left"):               K("M-Left"),        # Go Back
     K("RC-Right"):              K("M-Right"),       # Go Forward
     K("RC-Up"):                 K("M-Up"),          # Go Up dir


### PR DESCRIPTION
@rbreaves 

Some good updates to the Finder mods here. 

- Make labels a bit more clear. 
- Clean up a lot of formatting/alignment for readability. 
- Make tab nav with braces work in Deepin's dde-file-manager (Ctrl+Shift+Tab/Ctrl+Tab)
- Optional (disabled) shortcut to make new Nautilus windows remap to a system shortcut of Cmd+Option+Space (Ctrl+Alt+Space). 
- Enable Cmd+Braces to supplement Cmd+Left/Right for back-forward nav in all file managers (verified these are working shortcuts in macOS Finder). Uses the same remap as Ctrl+Left/Right to Alt+Left/Right, so works in all supported file managers. One more similarity to make file managers behave the same as web browsers. 
- Bring as much order as possible to the chaos of folder view shortcuts. 

Six file managers approximate the Finder's view options of Cmd+1 (Icons), Cmd+2 (Detailed List), Cmd+3 (Compact list or columns). Eight can do at least the first two views. Now all file managers will use the same folder view for the same Cmd+1/2/3 equivalent. 

Nautilus has two view modes and the shortcuts were reversed. Dolphin has three and was partially reversed. PCManFM has four, with three shortcuts out of order. All fixed to match Finder as closely as possible with this patch. 

Merry Christmas to all, and to all a good night!

Attaching for reference the latest updated spreadsheet matrix of keyboard shortcuts involved in the Finder Mods: 

[Finder_keyboard_shortcut_mapping_project_2021-12-25.xlsx](https://github.com/rbreaves/kinto/files/7776725/Finder_keyboard_shortcut_mapping_project_2021-12-25.xlsx)
