### PR TITLE
Tab navigation in terminals with Cmd+Shift+Braces

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -757,6 +757,8 @@ define_keymap(re.compile(termStr, re.IGNORECASE),{
     K("RC-P"): K("C-Shift-P"),
     K("RC-LEFT_BRACE"): K("C-Shift-LEFT_BRACE"),
     K("RC-RIGHT_BRACE"): K("C-Shift-RIGHT_BRACE"),
+    K("RC-Shift-Left_Brace"):   K("C-Page_Up"),     # Go to prior tab (Left)
+    K("RC-Shift-Right_Brace"):  K("C-Page_Down"),   # Go to next tab (Right)
     K("RC-A"): K("C-Shift-A"),
     K("RC-S"): K("C-Shift-S"),
     K("RC-D"): K("C-Shift-D"),


### PR DESCRIPTION
This update activates tab navigation (prior/next tab, left/right) in terminals, with Ctrl+Shift+Braces (Cmd+Shift+Braces in macOS). 

Verified this is a working shortcut in macOS Mojave, on a 2011 MacBook Pro. Works for tab nav in both Apple's Terminal.app and iTerm2. The Ctrl+PgUp/PgDn shortcut that works for terminal tab nav in Linux does nothing in macOS. 

This is the same shortcut remap that is working for tab nav in web browsers and file managers. All tested working in macOS.