### PR TITLE
Cmd+Shift+Braces for tab/view nav in codeStr apps

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -606,10 +606,12 @@ define_keymap(re.compile(codeStr, re.IGNORECASE),{
     K("M-Shift-Left"): [K("M-F19"),K("C-Shift-Left")],      # Select Left of Word
     K("M-Shift-Right"): [K("M-F19"),K("C-Shift-Right")],    # Select Right of Word
 
-    # K("C-PAGE_DOWN"): pass_through_key,         # cancel next_view
-    # K("C-PAGE_UP"): pass_through_key,           # cancel prev_view
-    K("C-M-Left"): K("C-PAGE_UP"),              # next_view
-    K("C-M-Right"): K("C-PAGE_DOWN"),           # prev_view
+    # K("C-PAGE_DOWN"):         pass_through_key,             # cancel next_view
+    # K("C-PAGE_UP"):           pass_through_key,             # cancel prev_view
+    K("C-M-Left"):              K("C-PAGE_UP"),             # next_view
+    K("C-M-Right"):             K("C-PAGE_DOWN"),           # prev_view
+    K("RC-Shift-Left_Brace"):   K("C-PAGE_UP"),             # next_view
+    K("RC-Shift-Right_Brace"):  K("C-PAGE_DOWN"),           # prev_view
 
     # VS Code Shortcuts
     K("C-g"): pass_through_key,                 # cancel Go to Line...


### PR DESCRIPTION
Cmd+Shift+Braces (in addition to the already existing remap of Opt+Cmd+Left/Right) is a verified working alternate shortcut for tab (view) navigation in VSCodium on macOS. 

While Cmd+Braces advances and retracts the indent/tabbing level, these Cmd+Shift+Braces shortcuts (logical Ctrl+Shift+Braces, physical Alt+Shift+Braces on PC keyboard) appear to do nothing in the Linux version of VSCode without this remap. 

Enabling this will bring the Cmd+Shift+Braces tab navigation behavior in the "codes" apps in line with the same behavior in macOS for web browser tabs, terminal tabs and file manager tabs.