### PR TITLE
Cmd+Shift+Left/Right for tab nav in terminals

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -493,6 +493,12 @@ define_keymap(lambda wm_class: wm_class.casefold() not in terminals,{
     K("RC-Dot"): K("Esc"),                        # Mimic macOS Cmd+dot = Escape key (not in terminals)
 })
 
+# Special overrides for terminals for shortcuts that conflict with General GUI block below.
+define_keymap(re.compile(termStr, re.IGNORECASE),{
+    K("RC-Shift-Left"):         K("C-Page_Up"),     # Go to prior tab (Left)
+    K("RC-Shift-Right"):        K("C-Page_Down"),   # Go to next tab (Right)
+},"Special overrides for terminals")
+
 # None referenced here originally
 # - but remote clients and VM software ought to be set here
 # These are the typical remaps for ALL GUI based apps


### PR DESCRIPTION
This addition enables the verified alternate macOS terminal shortcuts for tab navigation of Cmd+Shift+Left/Right (physical Alt+Shift+Left/Right, logical Ctrl+Shift+Left/Right on a PC keyboard). Shortcuts checked in Terminal.app and iTerm2. This is a functioning macOS terminal tab nav shortcut alongside Cmd+Shift+Braces. It also works in the Finder for tab nav, and has always been incorporated in the Finder mods. 

For this to work it has to go into this secondary "special overrides" block just above the General GUI block, because it conflicts with the "Wordwise" shortcuts inside the General GUI block. Without this special code block above General GUI, this remap will fail to work. 

The "wordwise" shortcuts without this remap seems to just make the terminal scroll up to the top of the buffer (RC+Shift+Left) and down to the bottom (RC+Shift+Right). So the shortcut without the remap doesn't seem to perform any desired "wordwise" action such as selecting to beginning of line, the way that it would in a text editor. On macOS, even with a lot of lines in a buffer, the Shift+Home/End shortcuts that the wordwise is remapping to appear to do nothing, so there doesn't seem to be that specific kind of "wordwise" action functioning in the terminals in macOS. 

Let me know if you feel for some reason it is undesirable to override this "wordwise" shortcut in terminals in favor of its behavior in macOS, or if this code block should maybe be moved above the block just above it. I just put it where it made things work for now, right above General GUI.