### PR TITLE
Disable Duplicate (Cmd+D) shortcut in file managers

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -411,7 +411,7 @@ define_keymap(re.compile(filemanagerStr, re.IGNORECASE),{
     ###########################################################################################################
     K("RC-Super-o"):    K("RC-Shift-o"),        # Open in new window (or tab, depends on FM setup) [not universal]
     K("RC-Backspace"):  K("Delete"),	        # Move to Trash (delete)
-    K("RC-D"):          [K("RC-C"),K("RC-V")],  # Mimic Finder's Duplicate command (Copy, then Paste)
+    # K("RC-D"):          [K("RC-C"),K("RC-V")],  # Duplicate file/folder (Copy, then Paste) [conflicts with "Add Bookmark"]
     ###########################################################################################################
     ###  To enable renaming files with the Enter key, uncomment the two keymapping lines just below this.   ###
     ###  Use Ctrl+Shift+Enter to escape or activate text fields such as "[F]ind" and "[L]ocation" fields.   ###


### PR DESCRIPTION
As much as I enjoy the convenience of the Cmd+D (Duplicate file/folder) shortcut, I have reluctantly made the decision that for most users it would be best to disable it by default, since it conflicts with the inherited function of "Add Bookmark" that Linux file managers like Nautilus have started using in parity with web browsers. Just one more thing that makes it easier to slide between web browsers and file "browsers". 

It's fun but has never been a "necessary" shortcut since a quick Cmd+C/Cmd+V will always accomplish the same thing. No one but me should miss it being active, and it will no longer interfere by default with bookmarking locations in Nautilus or any other file manager with that function assigned to Cmd+D (Ctrl+D). 

Anyone who really wants it can re-enable it.