### PR TITLE
Add cutefish-terminal and cutefish-filemanager

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -9,6 +9,7 @@ from xkeysnail.transform import *
 # xbindkeys -mk
 terminals = [
     "alacritty",
+    "cutefish-terminal",
     "deepin-terminal",
     "eterm",
     "gnome-terminal",
@@ -356,6 +357,7 @@ define_keymap(re.compile("thunar", re.IGNORECASE),{
 
 filemanagers = [
     "caja",
+    "cutefish-filemanager",
     "dde-file-manager",
     "dolphin",
     "io.elementary.files",


### PR DESCRIPTION
The CutefishOS apps seem to have somewhat limited support for keyboard shortcuts in general, but what they do support is working as expected after adding their WM_CLASSes to the config file.