### PR TITLE
Added missing libvte dependency

### DIFF
--- a/xkeysnail_service.sh
+++ b/xkeysnail_service.sh
@@ -305,6 +305,7 @@ fi
 
 if [[ $distro == "elementaryos" ]]; then
 	gsettings set io.elementary.terminal.settings natural-copy-paste false
+	sudo ./linux/system-config/unipkg.sh libvte-2.91-dev
 fi
 
 if ! [ -x "$(command -v xhost)" ] || ! [ -x "$(command -v gcc)" ]; then


### PR DESCRIPTION
The libvte dev library is missing when installing on Elementary OS (6.1).
Added its installation.

I do not know if this is the right place to introduce the installation of the
missing dependency. But I had to install it manually on Elementary OS 6.1
to make kinto start without a Python exception.