### PR TITLE
#622: Mirror umlaut behavior from macos with ahk

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -858,3 +858,28 @@ Send {LWin up}
 Send {RShift up}
 Send {LShift up}
 return
+
+#IfWinNotActive ahk_group remotes
+    $!u::Goto, ActivateUmlautModifier
+    $!s::Send, ß
+
+    ActivateUmlautModifier:
+    StringCaseSense, On
+    ; watch next input string
+	Input, UserInput, L1 B
+    if UserInput = o
+        Send, ö
+    else if UserInput = O
+        Send, Ö
+    else if UserInput = a
+        Send, ä
+    else if UserInput = A
+        Send, Ä
+    else if UserInput = u
+        Send, ü
+    else if UserInput = U
+        Send, Ü
+    else
+        Send, %UserInput%
+    return
+#If


### PR DESCRIPTION
This aims to mirror the macos behavior for writing "Umlauts":

You can activate a modifier by hitting Option+u. If the next written character can be transformed into an "Umlaut", it's getting transformed.

Solves https://github.com/rbreaves/kinto/issues/622