### PR TITLE
Add Deepin Browser to browsers and chromes WM_CLASS lists

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -75,6 +75,7 @@ browsers = [
     "Google-chrome",
     "microsoft-edge",
     "microsoft-edge-dev",
+    "org.deepin.browser",
 ]
 browsers = [browser.casefold() for browser in browsers]
 browserStr = "|".join(str('^'+x+'$') for x in browsers)
@@ -85,6 +86,7 @@ chromes = [
     "Google-chrome",
     "microsoft-edge",
     "microsoft-edge-dev",
+    "org.deepin.browser",
 ]
 chromes = [chrome.casefold() for chrome in chromes]
 chromeStr = "|".join(str('^'+x+'$') for x in chromes)


### PR DESCRIPTION
Adding the WM_CLASS for Deepin Browser (org.deepin.browser) to the general browsers and the Chromes WM_CLASS lists. Browser is based on Chromium.