### PR TITLE
[Win] Optional fix for media arrow keys (new)

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -62,6 +62,8 @@ Menu, Tray, Add, Autodetect Keyboards, autodetect
 ; Menu, Tray, check, Autodetect Keyboards ; Autodetect
 ; Menu, Tray, disable, Autodetect Keyboards ; CB/IBM
 Menu, Tray, Add, Suspend Kinto, tray_suspend
+; Add tray menu item for toggling media_arrows_fix
+Menu, Tray, Add, Media Arrows Fix   Shift+Opt+Cmd+M, toggle_media_arrows_fix
 ; Menu, Tray, Add, Returns to Desktop, min
 Menu, Tray, Add
 Menu, Tray, Add, Close, Exit
@@ -126,6 +128,12 @@ Exit() {
         WinClose
 
     ExitApp
+}
+
+; Set this variable to 1 to ENABLE Media Arrows Fix by default
+media_arrows_fix:=1
+if (media_arrows_fix=1) {
+    Menu, Tray, Check, Media Arrows Fix   Shift+Opt+Cmd+M
 }
 
 SetTitleMatchMode, 2
@@ -864,6 +872,43 @@ Send {LWin up}
 Send {RShift up}
 Send {LShift up}
 return
+
+; ##########################################################################################
+; ###   MEDIA ARROWS FIX
+; ###   Fix to make laptops with media functions on arrow keys act like Apple laptops
+; ###   To set this to ENABLED by default, search for "Enable Media Arrows Fix by default"
+; ##########################################################################################
+
+; Shortcut to activate media arrow keys fix
+^+!m::Gosub, toggle_media_arrows_fix
+
+; Function for activation of media arrows fix by tray menu item or keyboard shortcut
+toggle_media_arrows_fix:
+    media_arrows_fix:=!media_arrows_fix         ; Toggle value of optspecialchars variable on/off
+    if (media_arrows_fix = 1) {
+        Menu, Tray, Check, Media Arrows Fix   Shift+Opt+Cmd+M
+        MsgBox, 0, ALERT, % "Media Arrows Fix is now ENABLED.`n`n"
+                            . "When used with the Fn key, arrow keys with `n"
+                            . "media functions will now behave as if they are`n"
+                            . "PgUp/PgDn/Home/End navigation keys.`n`n"
+                            . "To ENABLE by default, search in kinto.ahk for`n"
+                            . "   'Enable Media Arrows Fix by default'`n`n"
+                            . "Disable from tray menu or with Shift+Opt+Cmd+M."
+        return
+    }
+    if (media_arrows_fix = 0) {
+        Menu, Tray, Uncheck, Media Arrows Fix   Shift+Opt+Cmd+M
+        MsgBox, 0, ALERT, Media arrow keys fix is now DISABLED.
+        return
+    }
+
+#If !WinActive("ahk_group remotes") && media_arrows_fix = 1
+    ; Fix for media functions on laptop arrow keys
+    $Media_Play_Pause::PgUp
+    $Media_Stop::PgDn
+    $Media_Prev::Home
+    $Media_Next::End
+#If
 
 #IfWinNotActive ahk_group remotes
     $!u::Goto, ActivateUmlautModifier


### PR DESCRIPTION
Replacement for PR #722. This does the same thing but in a much smarter way with fewer lines. 

Apple laptop keyboards have the PgUp/PgDn/Home/End navigation functions on Fn+arrow keys (even if not explicitly labeled on the keys). Most PC laptops also have these functions on the arrow keys, but some PC laptop keyboards have media functions (Play_Pause/Stop/Prev/Next) on the arrow keys instead. This makes it impossible to use the Fn+arrow keys for shortcuts like text selection (with Shift), or general navigation.

This optional fix for this issue (disabled by default) will cause media arrow keys to behave like an Apple keyboard when used with the Fn key. All possible modifier combinations are mapped to what they would have been without Kinto's modifier remap.

This PR creates a new tray menu item that will toggle the fix on and off, and it can be toggled with Shift+Opt+Cmd+M. The tray menu item will update with a check mark when the fix is active, and a MsgBox alerts the user when it is toggled on and off.

If desired the user can set the fix to be enabled by default by changing a single variable value near the top of kinto.ahk. The toggles to disable/enable will still function.

Companion to part of PR #499 which is for Linux.