### PR TITLE
[Win] Enhance OptSpecialChars dead keys processing

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -943,7 +943,6 @@ toggle_optspecialchars:
     }
     return
 
-; #IfWinNotActive ahk_group remotes
 #If !WinActive("ahk_group remotes") && optspecialchars = 1
 
     ; ######   NUMBER KEYS ROW   ######
@@ -954,39 +953,43 @@ toggle_optspecialchars:
     $!SC029::
         ; Use Apple "dead keys" Option key method to attach accents to next character typed
         ; Grave accent activated by Option+` (Alt plus scan code SC029, or !SC029)
+        Send, {U+0060}{Shift down}{Left}{Shift up}
         StringCaseSense, On
         ; watch next input string
-        Input, UserInput, L1 
-        Switch UserInput {
-            Case Esc: Return            ; Watch for Escape key, cancel dead keys sequence
-            Case "a": Send, {U+00E0}              ; à {U+00E0} (Alt+0224)
-            Case "e": Send, {U+00E8}              ; è {U+00E8} (Alt+0232)
-            Case "i": Send, {U+00EC}              ; ì {U+00EC} (Alt+0236)
-            Case "o": Send, {U+00F2}              ; ò {U+00F2} (Alt+0242)
-            Case "u": Send, {U+00F9}              ; ù {U+00F9} (Alt+0249)
-            Case "A": Send, {U+00C0}              ; À {U+00C0} (Alt+0192)
-            Case "E": Send, {U+00C8}              ; È {U+00C8} (Alt+0200)
-            Case "I": Send, {U+00CC}              ; Ì {U+00CC} (Alt+0204)
-            Case "O": Send, {U+00D2}              ; Ò {U+00D2} (Alt+0210)
-            Case "U": Send, {U+00D9}              ; Ù {U+00D9} (Alt+0217)
-            Default: Send, %UserInput%          ; No match? Send input through.
+        Input, UserInput, L1
+        ; MsgBox % GetKeyName(UserInput)        ; Test for key name
+        name := GetKeyName(UserInput)
+        Switch {
+            Case name = "Escape": Send, {Right} ; Escape: Leave accent character, exit dead key
+            Case name = "Space": Send, {Right}  ; Space: Leave accent character, exit dead key
+            Case name = "a": Send, {U+00E0}     ; à {U+00E0} (Alt+0224)
+            Case name = "e": Send, {U+00E8}     ; è {U+00E8} (Alt+0232)
+            Case name = "i": Send, {U+00EC}     ; ì {U+00EC} (Alt+0236)
+            Case name = "o": Send, {U+00F2}     ; ò {U+00F2} (Alt+0242)
+            Case name = "u": Send, {U+00F9}     ; ù {U+00F9} (Alt+0249)
+            Case name = "A": Send, {U+00C0}     ; À {U+00C0} (Alt+0192)
+            Case name = "E": Send, {U+00C8}     ; È {U+00C8} (Alt+0200)
+            Case name = "I": Send, {U+00CC}     ; Ì {U+00CC} (Alt+0204)
+            Case name = "O": Send, {U+00D2}     ; Ò {U+00D2} (Alt+0210)
+            Case name = "U": Send, {U+00D9}     ; Ù {U+00D9} (Alt+0217)
+            Default: Send, {Right}%UserInput%   ; No match? Leave accent char and send input.
         }
         Return
 
     ; ###   SC029 is ` (Grave key above Tab)
     $!+SC029::Send, {U+0060} ; Grave Accent diacritic (non-combining) {U+0060}: ` (Alt+96)
     $!1::Send,  {U+00A1} ; Inverted Exclamation Mark {U+00A1}: ¡ (Alt+0161)
-    $!+1::Send, {U+2044} ; Fraction Slash, solidus (U+2044): ⁄ (Alt+8260) [Needs Unicode]
+    $!+1::Send, {U+2044} ; Fraction Slash, solidus {U+2044}: ⁄ (Alt+8260) [Needs Unicode]
     $!2::Send,  {U+2122} ; Trade Mark Sign Emoji {U+2122}: ™ (Alt+0153)
     $!+2::Send, {U+20AC} ; Euro currency symbol {U+20AC}: € (Alt+0128)
     $!3::Send,  {U+00A3} ; British Pound currency symbol {U+00A3}: £ (Alt+0163)
-    $!+3::Send, {U+2039} ; Single Left-Pointing Angle Quotation mark {U+2039}: (Alt+0139)
+    $!+3::Send, {U+2039} ; Single Left-Pointing Angle Quotation mark {U+2039}: ‹ (Alt+0139)
     $!4::Send,  {U+00A2} ; Cent currency symbol {U+00A2}: ¢ (Alt+0162)
-    $!+4::Send, {U+203A} ; Single Right-Pointing Angle Quotation mark (U+203A): (Alt+0155)
+    $!+4::Send, {U+203A} ; Single Right-Pointing Angle Quotation mark {U+203A}: › (Alt+0155)
     $!5::Send,  {U+221E} ; Infinity mathematical symbol {U+221E}: ∞ (Alt+236)
-    $!+5::Send, {U+FB01} ; fi latin small ligature: ﬁ (U+FB01) (Alt+64257) [Needs Unicode]
+    $!+5::Send, {U+FB01} ; fi Latin small ligature {U+FB01}: ﬁ (Alt+64257) [Needs Unicode]
     $!6::Send,  {U+00A7} ; Section symbol {U+00A7}: § (Alt+0167)
-    $!+6::Send, {U+FB02} ; fl small ligature: (U+FB02) (Alt+64258) [Needs Unicode.]
+    $!+6::Send, {U+FB02} ; fl Latin small ligature {U+FB02}: ﬂ (Alt+64258) [Needs Unicode]
     $!7::Send,  {U+00B6} ; Paragraph mark (Pilcrow) symbol {U+00B6}: ¶ (Alt+0182)
     $!+7::Send, {U+2021} ; Double dagger (cross) symbol {U+2021}: ‡ (Alt+0135)
     $!8::Send,  {U+2022} ; Bullet point symbol {U+2022}: • (Alt+0149) 
@@ -997,7 +1000,7 @@ toggle_optspecialchars:
     $!+0::Send, {U+201A} ; Single low-9 quotation mark {U+201A}: ‚ (Alt+0130) 
     $!-::Send,  {U+2013} ; En Dash symbol {U+2013}: – (Alt+0150)
     $!+-::Send, {U+2014} ; Em Dash symbol {U+2014}: — (Alt+0151)
-    $!=::Send,  {U+2260} ; Not Equal To symbol (U+2260): ≠ (Alt+8800) [Needs Unicode]
+    $!=::Send,  {U+2260} ; Not Equal To symbol {U+2260}: ≠ (Alt+8800) [Needs Unicode]
     $!+=::Send, {U+00B1} ; Plus Minus symbol {U+00B1}: ± (Alt+0177)
 
 
@@ -1008,7 +1011,7 @@ toggle_optspecialchars:
 
     $!q::Send,  {U+0153} ; Small oe (oethel) ligature {U+0153}: œ (Alt+0156)
     $!+q::Send, {U+0152} ; Capital OE (Oethel) ligature {U+0152}: Œ (Alt+0140)
-    $!w::Send,  {U+2211} ; N-Ary Summation (sigma) notation (U+2211}: ∑ [Needs Unicode]
+    $!w::Send,  {U+2211} ; N-Ary Summation (sigma) notation {U+2211}: ∑ [Needs Unicode]
     $!+w::Send, {U+201E} ; Double Low-9 Quotation mark {U+201E}: „ (Alt+0132)
 
     ; Dead_Keys_Accent_Acute
@@ -1016,22 +1019,26 @@ toggle_optspecialchars:
     $!e::
         ; Use Apple "dead keys" Option key method to attach accents to next character typed
         ; Acute accent activated by Option+e (logical Alt+e)
+        Send, {U+00B4}{Shift down}{Left}{Shift up}
         StringCaseSense, On
         ; watch next input string
-        Input, UserInput, L1 
-        Switch UserInput {
-            Case Esc: Return            ; Watch for Escape key, cancel dead keys sequence
-            Case "a": Send, {U+00E1}            ; á {U+00E1} (Alt+0225)
-            Case "e": Send, {U+00E9}            ; é {U+00E9} (Alt+0233)
-            Case "i": Send, {U+00ED}            ; í {U+00ED} (Alt+0237)
-            Case "o": Send, {U+00F3}            ; ó {U+00F3} (Alt+0243)
-            Case "u": Send, {U+00FA}            ; ú {U+00FA} (Alt+0250)
-            Case "A": Send, {U+00C1}            ; Á {U+00C1} (Alt+0193)
-            Case "E": Send, {U+00C9}            ; É {U+00C9} (Alt+0201)
-            Case "I": Send, {U+00CD}            ; Í {U+00CD} (Alt+0205)
-            Case "O": Send, {U+00D3}            ; Ó {U+00D3} (Alt+0211)
-            Case "U": Send, {U+00DA}            ; Ú {U+00DA} (Alt+0218)
-            Default: Send, %UserInput%          ; No match? Send input through.
+        Input, UserInput, L1
+        ; MsgBox % GetKeyName(UserInput)        ; Test for key name
+        name := GetKeyName(UserInput)
+        Switch {
+            Case name = "Esc": Send, {Right}    ; Escape: Leave accent character, exit dead key
+            Case name = "Space": Send, {Right}  ; Space: Leave accent character, exit dead key
+            Case name = "a": Send, {U+00E1}     ; á {U+00E1} (Alt+0225)
+            Case name = "e": Send, {U+00E9}     ; é {U+00E9} (Alt+0233)
+            Case name = "i": Send, {U+00ED}     ; í {U+00ED} (Alt+0237)
+            Case name = "o": Send, {U+00F3}     ; ó {U+00F3} (Alt+0243)
+            Case name = "u": Send, {U+00FA}     ; ú {U+00FA} (Alt+0250)
+            Case name = "A": Send, {U+00C1}     ; Á {U+00C1} (Alt+0193)
+            Case name = "E": Send, {U+00C9}     ; É {U+00C9} (Alt+0201)
+            Case name = "I": Send, {U+00CD}     ; Í {U+00CD} (Alt+0205)
+            Case name = "O": Send, {U+00D3}     ; Ó {U+00D3} (Alt+0211)
+            Case name = "U": Send, {U+00DA}     ; Ú {U+00DA} (Alt+0218)
+            Default: Send, {Right}%UserInput%   ; No match? Leave accent char and send input.
         }
         Return
 
@@ -1039,67 +1046,75 @@ toggle_optspecialchars:
     $!r::Send,  {U+00AE} ; Registered Trade Mark Sign {U+00AE}: ® (Alt+0174)
     $!+r::Send, {U+2030} ; Per mille symbol {U+2030}: ‰ (Alt+0137)
     $!t::Send,  {U+2020} ; Simple dagger (cross) symbol {U+2020}: † (Alt+0134)
-    $!+t::Send, {U+02C7} ; Caron/hacek diacritic (non-combining) (U+02C7): ˇ (Alt+0134)
+    $!+t::Send, {U+02C7} ; Caron/hacek diacritic (non-combining) {U+02C7}: ˇ (Alt+0134)
     $!y::Send,  {U+00A5} ; Yen currency symbol {U+00A5}: ¥ (Alt+0165)
-    $!+y::Send, {U+00C1} ; Latin Capital Letter a with Acute (U+00C1): Á (Alt+0193)
+    $!+y::Send, {U+00C1} ; Latin Capital Letter a with Acute {U+00C1}: Á (Alt+0193)
 
     ; Dead_Keys_Accent_Umlaut
     ; Umlaut/Diaeresis accent: Option+u, then key to accent
     $!u::
         ; Use Apple "dead keys" Option key method to attach accents to next character typed
         ; Umlaut/Diaeresis accent activated by Option+u (logical Alt+u)
+        Send, {U+00A8}{Shift down}{Left}{Shift up}
         StringCaseSense, On
         ; watch next input string
-        Input, UserInput, L1 
-        Switch UserInput {
-            Case Esc: Return            ; Watch for Escape key, cancel dead keys sequence
-            Case "a": Send, {U+00E4}            ; ä {U+00E4} (Alt+0228)
-            Case "e": Send, {U+00EB}            ; ë {U+00EB} (Alt+0235)
-            Case "i": Send, {U+00EF}            ; ï {U+00EF} (Alt+0239)
-            Case "o": Send, {U+00F6}            ; ö {U+00F6} (Alt+0246)
-            Case "u": Send, {U+00FC}            ; ü {U+00FC} (Alt+0252)
-            Case "y": Send, {U+00FF}            ; ÿ {U+00FF} (Alt+0255)
-            Case "A": Send, {U+00C4}            ; Ä {U+00C4} (Alt+0196)
-            Case "E": Send, {U+00CB}            ; Ë {U+00CB} (Alt+0203)
-            Case "I": Send, {U+00CF}            ; Ï {U+00CF} (Alt+0207)
-            Case "O": Send, {U+00D6}            ; Ö {U+00D6} (Alt+0214)
-            Case "U": Send, {U+00DC}            ; Ü {U+00DC} (Alt+0220)
-            Case "Y": Send, {U+0178}            ; Ÿ {U+0178} (Alt+0159)
-            Default: Send, %UserInput%          ; No match? Send input through.
+        Input, UserInput, L1
+        ; MsgBox % GetKeyName(UserInput)        ; Test for key name
+        name := GetKeyName(UserInput)
+        Switch {
+            Case name = "Esc": Send, {Right}    ; Escape: Leave accent character, exit dead key
+            Case name = "Space": Send, {Right}  ; Space: Leave accent character, exit dead key
+            Case name = "a": Send, {U+00E4}     ; ä {U+00E4} (Alt+0228)
+            Case name = "e": Send, {U+00EB}     ; ë {U+00EB} (Alt+0235)
+            Case name = "i": Send, {U+00EF}     ; ï {U+00EF} (Alt+0239)
+            Case name = "o": Send, {U+00F6}     ; ö {U+00F6} (Alt+0246)
+            Case name = "u": Send, {U+00FC}     ; ü {U+00FC} (Alt+0252)
+            Case name = "y": Send, {U+00FF}     ; ÿ {U+00FF} (Alt+0255)
+            Case name = "A": Send, {U+00C4}     ; Ä {U+00C4} (Alt+0196)
+            Case name = "E": Send, {U+00CB}     ; Ë {U+00CB} (Alt+0203)
+            Case name = "I": Send, {U+00CF}     ; Ï {U+00CF} (Alt+0207)
+            Case name = "O": Send, {U+00D6}     ; Ö {U+00D6} (Alt+0214)
+            Case name = "U": Send, {U+00DC}     ; Ü {U+00DC} (Alt+0220)
+            Case name = "Y": Send, {U+0178}     ; Ÿ {U+0178} (Alt+0159)
+            Default: Send, {Right}%UserInput%   ; No match? Leave accent char and send input.
         }
         Return
 
-    $!+u::Send, {U+00A8} ; Umlaut/Diaeresis diacritic (non-combining) {U+00A8}: (Alt+0168)
+    $!+u::Send, {U+00A8} ; Umlaut/Diaeresis diacritic (non-combining) {U+00A8}: ¨ (Alt+0168)
 
     ; Dead_Keys_Accent_Circumflex
     ; Circumflex accent: Option+i, then key to accent
     $!i::
         ; Use Apple "dead keys" Option key method to attach accents to next character typed
         ; Circumflex accent activated by Option+i (logical Alt+i)
+        Send, {U+02C6}{Shift down}{Left}{Shift up}
         StringCaseSense, On
         ; watch next input string
-        Input, UserInput, L1 
-        Switch UserInput {
-            Case Esc: Return            ; Watch for Escape key, cancel dead keys sequence
-            Case "a": Send, {U+00E2}            ; â {U+00E2} (Alt+0226)
-            Case "e": Send, {U+00EA}            ; ê {U+00EA} (Alt+0234)
-            Case "i": Send, {U+00EE}            ; î {U+00EE} (Alt+0238)
-            Case "o": Send, {U+00F4}            ; ô {U+00F4} (Alt+0244)
-            Case "u": Send, {U+00FB}            ; û {U+00FB} (Alt+0251)
-            Case "A": Send, {U+00C2}            ; Â {U+00C2} (Alt+0194)
-            Case "E": Send, {U+00CA}            ; Ê {U+00CA} (Alt+0202)
-            Case "I": Send, {U+00CE}            ; Î {U+00CE} (Alt+0206)
-            Case "O": Send, {U+00D4}            ; Ô {U+00D4} (Alt+0212)
-            Case "U": Send, {U+00DB}            ; Û {U+00DB} (Alt+0219)
-            Default: Send, %UserInput%          ; No match? Send input through.
+        Input, UserInput, L1
+        ; MsgBox % GetKeyName(UserInput)        ; Test for key name
+        name := GetKeyName(UserInput)
+        Switch {
+            Case name = "Esc": Send, {Right}    ; Escape: Leave accent character, exit dead key
+            Case name = "Space": Send, {Right}  ; Space: Leave accent character, exit dead key
+            Case name = "a": Send, {U+00E2}     ; â {U+00E2} (Alt+0226)
+            Case name = "e": Send, {U+00EA}     ; ê {U+00EA} (Alt+0234)
+            Case name = "i": Send, {U+00EE}     ; î {U+00EE} (Alt+0238)
+            Case name = "o": Send, {U+00F4}     ; ô {U+00F4} (Alt+0244)
+            Case name = "u": Send, {U+00FB}     ; û {U+00FB} (Alt+0251)
+            Case name = "A": Send, {U+00C2}     ; Â {U+00C2} (Alt+0194)
+            Case name = "E": Send, {U+00CA}     ; Ê {U+00CA} (Alt+0202)
+            Case name = "I": Send, {U+00CE}     ; Î {U+00CE} (Alt+0206)
+            Case name = "O": Send, {U+00D4}     ; Ô {U+00D4} (Alt+0212)
+            Case name = "U": Send, {U+00DB}     ; Û {U+00DB} (Alt+0219)
+            Default: Send, {Right}%UserInput%   ; No match? Leave accent char and send input.
         }
         Return
 
-    $!+i::Send, {U+02C6} ; Modifier Letter Circumflex Accent (U+02C6): ˆ (Alt+0137)
+    $!+i::Send, {U+02C6} ; Modifier Letter Circumflex Accent {U+02C6}: ˆ (Alt+0137)
     $!o::Send,  {U+00F8} ; Latin Small Letter o with Stroke {U+00F8}: ø (Alt+0248)
     $!+o::Send, {U+00D8} ; Latin Capital Letter O with Stroke {U+00D8}: Ø (Alt+0216)
     $!p::Send,  {U+03C0} ; Greek Small Letter Pi {U+03C0}: π (Alt+227)
-    $!+p::Send, {U+220F} ; N-Ary Product mathematical symbol (U+220F): ∏ [Needs Unicode]
+    $!+p::Send, {U+220F} ; N-Ary Product mathematical symbol {U+220F}: ∏ [Needs Unicode]
     $![::Send,  {U+201C} ; Left Double Quotation Mark {U+201C}: “ (Alt+0147)
     $!+[::Send, {U+201D} ; Right Double Quotation Mark {U+201D}: ” (Alt+8)
     $!]::Send,  {U+2018} ; Left Single Quotation Mark {U+2018}: ‘ (Alt+0145)
@@ -1131,7 +1146,7 @@ toggle_optspecialchars:
     $!+h::Send, {U+00D3} ; Latin Capital Letter O with Acute {U+00D3}: Ó (Alt+0211)
     $!j::Send,  {U+2206} ; Increment, laplace operator symbol {U+2206}: ∆ [Needs Unicode]
     $!+j::Send, {U+00D4} ; Latin Capital Letter O with Circumflex {U+00D4}: Ô (Alt+0212)
-    $!k::Send,  {U+02DA} ; Ring Above diacritic (non-combining) {U+02DA}: ˚ [Needs Unicode] (NOT degree sign/symbol)
+    $!k::Send,  {U+02DA} ; Ring Above diacritic (non-combining) {U+02DA}: ˚ [Needs Unicode]
 
     ; Apple logo {U+F8FF}:  [Unicode Private Use Area, req's Baskerville Old Face font]
     ; $!+k::Send, {U+F8FF}    ; This Unicode address only works with Mac fonts
@@ -1172,40 +1187,44 @@ toggle_optspecialchars:
 
     $!z::Send,  {U+03A9} ; Greek Capital Letter Omega symbol {U+03A9} Ω (Alt+234)
     $!+z::Send, {U+00B8} ; Spacing Cedilla diacritic symbol (non-combining) {U+00B8}: ¸ (Alt+0184)
-    $!x::Send,  {U+2248} ; Almost Equal To symbol (U+2248): ≈ (Alt+247)
-    $!+x::Send, {U+02DB} ; Ogonek diacritic (non-combining) (U+02DB): ˛ [Needs Unicode]
+    $!x::Send,  {U+2248} ; Almost Equal To symbol {U+2248}: ≈ (Alt+247)
+    $!+x::Send, {U+02DB} ; Ogonek diacritic (non-combining) {U+02DB}: ˛ [Needs Unicode]
     $!c::Send,  {U+00E7} ; Small Letter c with Cedilla {U+00E7}: ç (Alt+0231)
     $!+c::Send, {U+00C7} ; Capital Letter C with Cedilla {U+00C7}: Ç (Alt+0199)
-    $!v::Send,  {U+221A} ; Square Root radical sign (U+221A): √ (Alt+251)
-    $!+v::Send, {U+25CA} ; Lozenge (diamond) shape symbol (U+25CA): ◊ [Needs Unicode]
-    $!b::Send,  {U+222B} ; Integral mathematical symbol (U+222B): ∫ [Needs Unicode]
-    $!+b::Send, {U+0131} ; Latin Small Letter Dotless i (U+0131): ı [Needs Unicode]
+    $!v::Send,  {U+221A} ; Square Root radical sign {U+221A}: √ (Alt+251)
+    $!+v::Send, {U+25CA} ; Lozenge (diamond) shape symbol {U+25CA}: ◊ [Needs Unicode]
+    $!b::Send,  {U+222B} ; Integral mathematical symbol {U+222B}: ∫ [Needs Unicode]
+    $!+b::Send, {U+0131} ; Latin Small Letter Dotless i {U+0131}: ı [Needs Unicode]
 
     ; Dead_Keys_Accent_Tilde
     ; Tilde accent: Option+n, then key to accent
     $!n::
         ; Use Apple "dead keys" Option key method to attach accents to next character typed
         ; Tilde accent activated by Option+n (logical Alt+n)
+        Send, {U+02DC}{Shift down}{Left}{Shift up}
         StringCaseSense, On
         ; watch next input string
-        Input, UserInput, L1 
-        Switch UserInput {
-            Case Esc: Return            ; Watch for Escape key, cancel dead keys sequence
-            Case "a": Send, {U+00E3}            ; ã {U+00E3} (Alt+0227)
-            Case "n": Send, {U+00F1}            ; ñ {U+00F1} (Alt+0241)
-            Case "o": Send, {U+00F5}            ; õ {U+00F5} (Alt+0245)
-            Case "A": Send, {U+00C3}            ; Ã {U+00C3} (Alt+0195)
-            Case "N": Send, {U+00D1}            ; Ñ {U+00D1} (Alt+0209)
-            Case "O": Send, {U+00D5}            ; Õ {U+00D5} (Alt+0213)
-            Default: Send, %UserInput%          ; No match? Send input through.
+        Input, UserInput, L1
+        ; MsgBox % GetKeyName(UserInput)        ; Test for key name
+        name := GetKeyName(UserInput)
+        Switch {
+            Case name = "Esc": Send, {Right}    ; Escape: Leave accent character, exit dead key
+            Case name = "Space": Send, {Right}  ; Space: Leave accent character, exit dead key
+            Case name = "a": Send, {U+00E3}     ; ã {U+00E3} (Alt+0227)
+            Case name = "n": Send, {U+00F1}     ; ñ {U+00F1} (Alt+0241)
+            Case name = "o": Send, {U+00F5}     ; õ {U+00F5} (Alt+0245)
+            Case name = "A": Send, {U+00C3}     ; Ã {U+00C3} (Alt+0195)
+            Case name = "N": Send, {U+00D1}     ; Ñ {U+00D1} (Alt+0209)
+            Case name = "O": Send, {U+00D5}     ; Õ {U+00D5} (Alt+0213)
+            Default: Send, {Right}%UserInput%   ; No match? Leave accent char and send input.
         }
         Return
 
-    $!+n::Send, {U+02DC} ; Small Tilde character (U+02DC): ˜ (Alt+0152)
+    $!+n::Send, {U+02DC} ; Small Tilde character {U+02DC}: ˜ (Alt+0152)
     $!m::Send,  {U+00B5} ; Micro (mu) symbol {U+00B5}: µ (Alt+0181)
-    $!+m::Send, {U+00C2} ; Latin Capital Letter a with Circumflex (U+00C2): Â (Alt+0194)
+    $!+m::Send, {U+00C2} ; Latin Capital Letter a with Circumflex {U+00C2}: Â (Alt+0194)
     $!,::Send,  {U+2264} ; Less than or equal to symbol {U+2264}: ≤ (Alt+243)
-    $!+,::Send, {U+00AF} ; Macron/overline/apl overbar (non-combining) (U+00AF): ¯ (Alt+0175)
+    $!+,::Send, {U+00AF} ; Macron/overline/apl overbar (non-combining) {U+00AF}: ¯ (Alt+0175)
     $!.::Send,  {U+2265} ; Greater than or equal to symbol {U+2265}: ≥ (Alt+242)
     $!+.::Send, {U+02D8} ; Breve diacritic (non-combining) {U+02D8}: ˘ [Needs Unicode]
     $!/::Send,  {U+00F7} ; Obelus/Division symbol {U+00F7}: ÷ (Alt+0247)


### PR DESCRIPTION
Adds more accurate and intuitive behavior to the process of using dead keys, to match macOS more closely, and fixes some of the Switch/Case lines that weren't working as expected (Escape, Space were not actually activating). 

Dead keys sequences will now place the pending accent diacritic character in a highlight, then either replace it with an accented character if there is a match, or deselect the diacritic character and exit the dead keys sequence, leaving the diacritic character visible. Any input other than Escape or Space or a matching letter will be passed through. This is a match for how dead keys work in macOS. 

Includes the updated comments and typo fixes, so I'll close PR #726.