### PR TITLE
Mac numpad feature

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -276,6 +276,66 @@ define_keymap(re.compile("^jetbrains-(?!.*toolbox).*$", re.IGNORECASE),{
     K("Super-c"): K("LC-c"),                    # Sigints - interrupt
 },"Jetbrains")
 
+#########################################################
+###########   START OF MAC NUMPAD FEATURE   #############
+#########################################################
+# Force the numpad to always be a numpad, like a Mac keyboard on macOS
+# Numlock key becomes "Clear" key for use with calculator (sends Escape)
+# Toggle feature on/off with Option+Numlock (Fn+Numlock might work on Apple keyboards)
+# Set _mac_numpad var to "False" (no quotes) to disable by default
+_mac_numpad = True
+_mac_numpad_first_run = True
+
+def mac_numpad_alert():
+    global _mac_numpad_first_run
+    if _mac_numpad:
+        run('notify-send -u critical ALERT "Kinto Mac Numpad is now ENABLED.\
+            \rNumlock == Clear (Escape)\
+            \rDisable with Option+Numlock."', shell=True)
+        print("(DD) Kinto Mac Numpad is now ENABLED.", flush=True)
+    # Don't show pointless alert on startup if feature is set to be disabled by default
+    if not _mac_numpad and not _mac_numpad_first_run:
+        run('notify-send ALERT "Kinto Mac Numpad is now DISABLED.\
+            \rRe-enable with Option+Numlock."', shell=True)
+        print("(DD) Kinto Mac Numpad is now DISABLED.", flush=True)
+    _mac_numpad_first_run = False
+
+
+mac_numpad_alert()
+
+
+def toggle_mac_numpad():
+    """Toggle the value of the _optspecialchars variable"""
+    from subprocess import run
+    def _toggle_mac_numpad():
+        global _mac_numpad
+        _mac_numpad = not _mac_numpad
+        mac_numpad_alert()
+
+    return _toggle_mac_numpad
+
+
+define_keymap(lambda wm_class: wm_class.casefold() not in remotes,{
+    C("Alt-Numlock"):       toggle_mac_numpad(),
+    C("Fn-Numlock"):        toggle_mac_numpad(),
+},"Mac Numpad toggle")
+
+define_keymap(lambda wm_class: wm_class.casefold() not in remotes and _mac_numpad is True,{
+    C("KP1"):               C("1"),
+    C("KP2"):               C("2"),
+    C("KP3"):               C("3"),
+    C("KP4"):               C("4"),
+    C("KP5"):               C("5"),
+    C("KP6"):               C("6"),
+    C("KP7"):               C("7"),
+    C("KP8"):               C("8"),
+    C("KP9"):               C("9"),
+    C("KP0"):               C("0"),
+    C("KPDot"):             C("Dot"),
+    C("Numlock"):           C("Esc"),
+},"Mac Numpad")
+
+
 ##############################################
 ### START OF FILE MANAGER GROUP OF KEYMAPS ###
 ##############################################

--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -64,6 +64,8 @@ Menu, Tray, Add, Autodetect Keyboards, autodetect
 Menu, Tray, Add, Suspend Kinto, tray_suspend
 ; Add tray menu item for toggling Option key special character entry scheme
 Menu, Tray, Add, OptSpecialChars   Shift+Opt+Cmd+O, toggle_optspecialchars
+; Add tray menu item for toggling mac_numpad
+Menu, Tray, Add, Mac Numpad           Option+NumLock, toggle_mac_numpad
 ; Menu, Tray, Add, Returns to Desktop, min
 Menu, Tray, Add
 Menu, Tray, Add, Close, Exit
@@ -128,6 +130,13 @@ Exit() {
         WinClose
 
     ExitApp
+}
+
+; Set this variable to 1 to ENABLE Mac Numpad feature by default
+mac_numpad:=1
+if (mac_numpad=1) {
+    SetNumLockState, AlwaysOn
+    Menu, Tray, Check, Mac Numpad           Option+NumLock
 }
 
 SetTitleMatchMode, 2
@@ -917,6 +926,42 @@ Send {LWin up}
 Send {RShift up}
 Send {LShift up}
 return
+
+
+; ##########################################################################################
+; ###   MAC NUMPAD FEATURE
+; ###   Make the numpad always act like a numpad, even when numlock is OFF
+; ###   Numlock becomes "Clear" key for use with calculator apps (sends Escape)
+; ###   
+; ###   To enable this feature by default: 
+; ###   Search for "ENABLE Mac Numpad feature" and set the variable to 1
+; ##########################################################################################
+
+; Shortcut to activate media arrow keys fix
+; ^+!n::Gosub, toggle_mac_numpad
+$!NumLock::Gosub, toggle_mac_numpad
+
+; Function (subroutine?) for activation by tray menu item or keyboard shortcut
+toggle_mac_numpad:
+    mac_numpad:=!mac_numpad         ; Toggle value of media_arrows_fix variable on/off
+    if (mac_numpad = 1) {
+        Menu, Tray, Check, Mac Numpad           Option+NumLock
+        MsgBox, 0, ALERT, % "Mac Numpad feature is now ENABLED.`n`n"
+                            . "Disable from tray menu or with Option+NumLock."
+        return
+    }
+    if (mac_numpad = 0) {
+        Menu, Tray, Uncheck, Mac Numpad           Option+NumLock
+        MsgBox, 0, ALERT, % "Mac Numpad feature is now DISABLED.`n`n"
+                            . "Re-enable from tray menu or with Option+NumLock."
+        return
+    }
+
+#If !WinActive("ahk_group remotes") && mac_numpad = 1
+    ; Make numpad act like a real Mac (always a numpad, Numlock is "Clear")
+    $NumLock::Send, {Esc}
+#If ; Technically unnecessary closing #If, but nullifies previous #If directive
+
 
 ; ###############################################################################################################
 ; ###   Special character insertion like Apple/macOS Option key methods, mapping to Unicode input method


### PR DESCRIPTION
Additions to both the Windows and Linux config files to enable the feature of making the numpad behave like a real Mac keyboard. Numbers are always numbers, Numlock key becomes "Clear", which sends Escape. 

Feature can be disabled and re-enabled with Option+Numlock. Windows version adds a menu item with a check mark. 

Notifications or dialogs will appear on either platform to indicate that the feature has been enabled or disabled when using the shortcut. 

Since the goal of Kinto is to mimic an Apple keyboard, I will argue that it makes sense to have this feature enabled by default. The user can disable it by changing a variable value in the config file. 