### PR TITLE
GNOME input source switching shortcuts for terminals

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -776,6 +776,8 @@ define_keymap(re.compile("alacritty", re.IGNORECASE),{
 })
 
 define_keymap(re.compile(termStr, re.IGNORECASE),{
+    K("LC-Space"):          K("Super-Space"),       # switch keyboard input source (gnome)
+    K("Shift-LC-Space"):    K("Shift-Super-Space"), # switch keyboard input source in reverse (gnome)
     K("LC-RC-f"): K("Alt-F10"),                       # Toggle window maximized state
     # K("RC-Grave"): K("Super-Tab"),                # xfce4 Switch within app group
     # K("RC-Shift-Grave"): K("Super-Shift-Tab"),    # xfce4 Switch within app group


### PR DESCRIPTION
GNOME input source (keyboard layout) switching shortcuts are Super+Space and Shift+Super+Space, so they don't work in terminals where Super is not available. 

Only valid for GNOME, so it's tagged with "(gnome)". 