### PR TITLE
Fix Find/Replace options and Word Wrap shortcuts

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -639,6 +639,15 @@ define_keymap(lambda wm_class: wm_class.casefold() not in mscodes,{
 
 # Keybindings for VS Code
 define_keymap(re.compile(codeStr, re.IGNORECASE),{
+    # Find dialog options
+    C("Alt-RC-C"):              C("Alt-C"),                     # Find: toggle "Match Case"
+    C("Alt-RC-W"):              C("Alt-W"),                     # Find: toggle "Match Whole Word"
+    C("Alt-RC-R"):              C("Alt-R"),                     # Find: toggle "Use Regular Expression"
+    C("Alt-RC-L"):              C("Alt-L"),                     # Find: toggle "Find in Selection"
+    C("Alt-RC-P"):              C("Alt-P"),                     # Replace: toggle "Preserve Case"
+
+    C("Alt-RC-Z"):              C("Alt-Z"),                     # View: toggle "Word Wrap"
+
     K("Super-Space"): K("LC-Space"),                        # Basic code completion
     # Wordwise remaining - for VS Code
     # Alt-F19 hack fixes Alt menu activation


### PR DESCRIPTION
On macOS the entire keyboard (letters, numbers and punctuation) are dedicated to accessing special characters and "dead key" accented characters. Therefore Alt+key and Shift+Alt+key shortcuts are generally not usable on macOS (except for function keys and arrow keys, which have no associated special characters). 

This change will fix the following shortcuts to match the macOS version of VSCode/VSCodium apps. 

- Find dialog: toggle "Match Case"
- Find dialog: toggle "Match Whole Word"
- Find dialog: toggle "Use Regular Expression"
- Find dialog: toggle "Find in Selection"
- Replace dialog: toggle "Preserve Case"
- View menu: toggle "Word Wrap"

There are some other Alt and Shift-Alt based shortcuts in the settings, but they are somewhat more obscure commands, and they don't seem to have been fixed even on macOS, so they just don't work at all in the Mac version of the software.