### PR TITLE
Add support for non-default XDG user dir in an install script for the Linux

### DIFF
--- a/install/linux.sh
+++ b/install/linux.sh
@@ -2,12 +2,16 @@
 
 # /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/rbreaves/kinto/master/install/linux.sh)"
 
-wget https://github.com/rbreaves/kinto/archive/refs/heads/master.zip -O ~/Downloads/kinto.zip || curl https://github.com/rbreaves/kinto/archive/refs/heads/master.zip -J -L -o ~/Downloads/kinto.zip
-unzip ~/Downloads/kinto.zip -d ~/Downloads/
-cd ~/Downloads/kinto-master/
+# Find a download directory dynamically to support non-default XDG user dir.
+# In case the `xdg-user-dir` is not installed, fallback to the hardcoded path
+DOWNLOADS_DIR=$(xdg-user-dir DOWNLOAD || echo "${HOME}/Downloads")
+
+wget https://github.com/rbreaves/kinto/archive/refs/heads/master.zip -O ${DOWNLOADS_DIR}/kinto.zip || curl https://github.com/rbreaves/kinto/archive/refs/heads/master.zip -J -L -o ${DOWNLOADS_DIR}/kinto.zip
+unzip ${DOWNLOADS_DIR}/kinto.zip -d ${DOWNLOADS_DIR}/
+cd ${DOWNLOADS_DIR}/kinto-master/
 
 kintorelease=`wget -qO- https://api.github.com/repos/rbreaves/kinto/releases/latest | awk -F'tag_name": ' '{if ($2) print $2}' | tr -d \", || curl -s https://api.github.com/repos/rbreaves/kinto/releases/latest | awk -F'tag_name": ' '{if ($2) print $2}' | tr -d \",`
-kintohash=`unzip -z ~/Downloads/kinto.zip | tail -n1`
+kintohash=`unzip -z ${DOWNLOADS_DIR}/kinto.zip | tail -n1`
 kintoshort=${kintohash::7}
 
 echo "$kintorelease" "build" "$kintoshort" > ./dl_version


### PR DESCRIPTION
According to the <https://wiki.archlinux.org/title/XDG_user_directories> and <https://www.freedesktop.org/wiki/Software/xdg-user-dirs/>, Linux users can customize their "user directories" to be in a different paths than the default `~/Downloads` etc. _However_, the install script hardcoded this path so far, which caused a failure for such users, e.g.
```
$ ./install/linux.sh 
/home/dstasczak/Downloads/kinto.zip: No such file or directory
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Warning: Failed to open the file /home/dstasczak/Downloads/kinto.zip: No such 
Warning: file or directory
100   512    0   512    0     0    751      0 --:--:-- --:--:-- --:--:--   751
curl: (23) Failure writing output to destination
unzip:  cannot find or open /home/dstasczak/Downloads/kinto.zip, /home/dstasczak/Downloads/kinto.zip.zip or /home/dstasczak/Downloads/kinto.zip.ZIP.
…
```

**This PR is supposed to fix that**.

In case the fallback hardcoded path is used, there will be an error message written to the `STDERR`:
```
$ ./install/linux.sh 
./install/linux.sh: line 7: xdg-user-dir: command not found
```
This is the default error message that `bash` shows in case it cannot find a specific command, I think it's clear enough not to require implementing any custom handling. Let me know if you agree or not :slightly_smiling_face: 