### PR TITLE
[Win11] Tab nav with Cmd+Shift+Braces in Explorer

### DIFF
--- a/windows/kinto.ahk
+++ b/windows/kinto.ahk
@@ -224,6 +224,8 @@ GroupAdd, intellij, ahk_exe idea64.exe
 ; #########################################################################
 ; Finder Mods for Windows File Explorer (explore.exe)
 #IfWinActive ahk_class CabinetWClass ahk_exe explorer.exe
+    ^+[::Send ^+{Tab}           ; Tab nav: Go to prior tab (left)
+    ^+]::Send ^{Tab}            ; Tab nav: Go to next tab (right)
     ^i::Send !{Enter}           ; Cmd+i: Get Info / Properties
     ^r::Send {F5}               ; Cmd+R: Refresh view (Not actually a Finder shortcut? But works in Linux file browsers too.)
     ^1::Send ^+2                ; Cmd+1: View as Icons


### PR DESCRIPTION
Update 22H2 for Windows 11 has brought back tabs in Windows Explorer (the file manager). The tabs use Ctrl+Shift+Tab/Ctrl+Tab for tab navigation.

 This PR enables tab nav with Cmd+Shift+Braces (Ctrl+Shift+Braces) as an update to the Finder Mods section of `kinto.ahk`.