### PR TITLE
Add "Roxterm" to terminals list

### DIFF
--- a/linux/kinto.py
+++ b/linux/kinto.py
@@ -23,6 +23,7 @@ terminals = [
     "lxterminal",
     "mate-terminal",
     "org.gnome.Console",
+    "roxterm",
     "qterminal",
     "st",
     "sakura",


### PR DESCRIPTION
Roxterm is a terminal found in antiX Linux. 