### PR TITLE
Bugfix/term not set

### DIFF
--- a/linux/gui/kinto.desktop
+++ b/linux/gui/kinto.desktop
@@ -7,5 +7,5 @@ Type=Application
 Exec=/usr/bin/python3 {homedir}/.config/kinto/gui/kinto-gui.py
 Icon={homedir}/.config/kinto/kinto-color-48.svg
 # Icon=/usr/share/icons/Pocillo/kinto-color.svg
-Terminal=false
+Terminal=true
 NoDisplay=false

--- a/linux/gui/kinto.desktop
+++ b/linux/gui/kinto.desktop
@@ -4,8 +4,8 @@ Name=Kinto.sh
 GenericName=Kinto.sh
 Categories=Utility;
 Type=Application
-Exec=/usr/bin/python3 {homedir}/.config/kinto/gui/kinto-gui.py
+Exec=env TERM=dumb /usr/bin/python3 {homedir}/.config/kinto/gui/kinto-gui.py
 Icon={homedir}/.config/kinto/kinto-color-48.svg
 # Icon=/usr/share/icons/Pocillo/kinto-color.svg
-Terminal=true
+Terminal=false
 NoDisplay=false


### PR DESCRIPTION
By defining the `TERM` env to `dumb`, kinto stops flooding the logs with messages